### PR TITLE
Fix gcc setup in LCG images

### DIFF
--- a/centos7-lcg95apython3/Dockerfile
+++ b/centos7-lcg95apython3/Dockerfile
@@ -11,7 +11,7 @@ ENV LCG_RELEASE 95apython3
 ENV LCG_PLATFORM_BASE x86_64-centos7
 ENV LCG_PLATFORM ${LCG_PLATFORM_BASE}-gcc8-opt
 # branch/tag/commit reference for lcgcmake. we need a specific version
-# to be able to create an RPM-base view.
+# to be able to create an RPM-based view.
 ENV LCGCMAKE_REF 16176752
 
 # Add the LCG rpm repository as described here
@@ -27,18 +27,16 @@ RUN yum-config-manager --add-repo https://lcgpackages.web.cern.ch/lcgpackages/rp
     LCG_${LCG_RELEASE}_DD4hep_01_10_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_eigen_3.3.7_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_Geant4_10.05_${LCG_PLATFORM//-/_}.noarch \
-    LCG_${LCG_RELEASE}_lcgenv_1.3.8_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_ninja_1.7.2.gcc0ea.kitware.dyndep_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_pythia8_240_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_ROOT_6.16.00_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_tbb_2019_U1_${LCG_PLATFORM//-/_}.noarch \
   && yum -y clean all
 
-# Add missing directory links so the view creating script finds the compiler
-RUN mkdir --parents /opt/lcg/LCG_${LCG_RELEASE}/gcc/8 \
-  && ln --relative --symbolic --verbose \
-    /opt/lcg/gcc/8.2.0-3fa06/${LCG_PLATFORM_BASE} \
-    /opt/lcg/LCG_${LCG_RELEASE}/gcc/8/${LCG_PLATFORM_BASE}
+# Add missing directory link so the view creating script finds the compiler
+RUN ln -rsv /opt/lcg/gcc/8.2.0-3fa06 /opt/lcg/gcc/8
+# Bugfix for broken setup script
+ADD fixed-gcc-setup.sh /opt/lcg/gcc/8.2.0-3fa06/x86_64-centos7/setup.sh
 
 # Create the LCG view. Use a fixed location since there is only one
 # release/platform combination. This way, images with different
@@ -51,3 +49,4 @@ RUN git clone https://gitlab.cern.ch/sft/lcgcmake.git lcgcmake \
     -p ${LCG_PLATFORM} \
     /opt/lcg_view \
   && rm -rf lcgcmake
+

--- a/centos7-lcg95apython3/Dockerfile
+++ b/centos7-lcg95apython3/Dockerfile
@@ -5,7 +5,7 @@ FROM ${REGISTRY}/centos7:${TAG}
 LABEL description="CERN CentOS 7 with Acts dependencies from LCG 95apython3"
 LABEL maintainer="Paul Gessinger <paul.gessinger@cern.ch>"
 # increase whenever any of the RUN commands change
-LABEL version="3"
+LABEL version="4"
 
 ENV LCG_RELEASE 95apython3
 ENV LCG_PLATFORM_BASE x86_64-centos7
@@ -49,4 +49,3 @@ RUN git clone https://gitlab.cern.ch/sft/lcgcmake.git lcgcmake \
     -p ${LCG_PLATFORM} \
     /opt/lcg_view \
   && rm -rf lcgcmake
-

--- a/centos7-lcg95apython3/fixed-gcc-setup.sh
+++ b/centos7-lcg95apython3/fixed-gcc-setup.sh
@@ -45,8 +45,9 @@ fi
 # Export package specific environmental variables
 
 # see https://gcc.gnu.org/onlinedocs/gcc/Environment-Variables.html
-export COMPILER_PATH="$BASE/libexec/gcc/x86_64-pc-linux-gnu/${__PKG_VERSION}-${__PKG_HASH}"
-export LIBRARY_PATH="$BASE/lib/gcc/x86_64-pc-linux-gnu/${__PKG_VERSION}-${__PKG_HASH}${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH}"
+export COMPILER_PATH="${BASE}/libexec/gcc/x86_64-pc-linux-gnu/${__PKG_VERSION}-${__PKG_HASH}"
+export LIBRARY_PATH="${BASE}/lib/gcc/x86_64-pc-linux-gnu/${__PKG_VERSION}-${__PKG_HASH}${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH}"
+export CPLUS_INCLUDE_PATH="${BASE}/include/c++/${__PKG_VERSION}-${__PKG_HASH}:${BASE}/include/c++/${__PKG_VERSION}-${__PKG_HASH}/x86_64-pc-linux-gnu:${BASE}/lib/gcc/x86_64-pc-linux-gnu/${__PKG_VERSION}-${__PKG_HASH}/include:${BASE}/lib/gcc/x86_64-pc-linux-gnu/${__PKG_VERSION}-${__PKG_HASH}/include-fixed"
 
 export FC=`which gfortran`
 export CC=`which gcc`

--- a/centos7-lcg95apython3/fixed-gcc-setup.sh
+++ b/centos7-lcg95apython3/fixed-gcc-setup.sh
@@ -1,0 +1,53 @@
+if [[ -n "$BASH" ]]; then
+    SCRIPT_DIR=$BASH_SOURCE[0]
+else # assume that zsh
+    SCRIPT_DIR=${(%):-%x}
+fi
+
+BASE=$(dirname $(readlink -f $SCRIPT_DIR))
+PLATFORM=x86_64-centos7
+
+
+
+# Source dependencies
+BASE_STACK="${BASE} ${BASE_STACK}" # Add element to stack
+
+depends=$BASE/../../../binutils/2.30/$PLATFORM/setup.sh
+dependshash=$BASE/../../../binutils/2.30-e5b21/$PLATFORM/setup.sh
+if [[ -e "$dependshash" ]]; then
+    source $dependshash
+elif [[ -e "$depends" ]]; then
+    source $depends
+else
+    echo Could not find setup.sh file for package binutils 
+fi
+BASE=$(echo $BASE_STACK | cut -f1 -d' ' ) # Restore BASE 
+
+BASE_STACK=$(echo $BASE_STACK | cut -f2- -d' ') # Remove last element from stack
+
+__PKG_NAME=gcc
+__PKG_VERSION=8.2.0
+__PKG_HASH=3fa06
+
+# Export environmental variables
+export PATH=$BASE/bin:$PATH
+export MANPATH=$BASE/share/man:$MANPATH
+
+if [ -e "${BASE}/lib64" ]; then
+    # Add lib64 if exists
+    export LD_LIBRARY_PATH="$BASE/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+if [ -e "${BASE}/lib" ]; then
+    # Add lib if exists
+    export LD_LIBRARY_PATH="$BASE/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+
+# Export package specific environmental variables
+
+# see https://gcc.gnu.org/onlinedocs/gcc/Environment-Variables.html
+export COMPILER_PATH="$BASE/libexec/gcc/x86_64-pc-linux-gnu/${__PKG_VERSION}-${__PKG_HASH}"
+export LIBRARY_PATH="$BASE/lib/gcc/x86_64-pc-linux-gnu/${__PKG_VERSION}-${__PKG_HASH}${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH}"
+
+export FC=`which gfortran`
+export CC=`which gcc`
+export CXX=`which g++`

--- a/centos7-lcg96/Dockerfile
+++ b/centos7-lcg96/Dockerfile
@@ -5,7 +5,7 @@ FROM ${REGISTRY}/centos7:${TAG}
 LABEL description="CERN CentOS 7 with Acts dependencies from LCG 96"
 LABEL maintainer="Paul Gessinger <paul.gessinger@cern.ch>"
 # increase whenever any of the RUN commands change
-LABEL version="3"
+LABEL version="4"
 
 ENV LCG_RELEASE 96
 ENV LCG_PLATFORM_BASE x86_64-centos7
@@ -28,18 +28,16 @@ RUN yum-config-manager --add-repo https://lcgpackages.web.cern.ch/lcgpackages/rp
     LCG_${LCG_RELEASE}_eigen_3.3.7_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_Geant4_10.05.p01_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_hepmc3_3.1.1_${LCG_PLATFORM//-/_}.noarch \
-    LCG_${LCG_RELEASE}_lcgenv_1.3.8_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_ninja_1.9.0_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_pythia8_240_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_ROOT_6.18.00_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_tbb_2019_U7_${LCG_PLATFORM//-/_}.noarch \
   && yum -y clean all
 
-# Add missing directory links so the view creating script finds the compiler
-RUN mkdir --parents /opt/lcg/LCG_${LCG_RELEASE}/gcc/8 \
-  && ln --relative --symbolic --verbose \
-    /opt/lcg/gcc/8.2.0-3fa06/${LCG_PLATFORM_BASE} \
-    /opt/lcg/LCG_${LCG_RELEASE}/gcc/8/${LCG_PLATFORM_BASE}
+# Add missing directory link so the view creating script finds the compiler
+RUN ln -rsv /opt/lcg/gcc/8.2.0-3fa06 /opt/lcg/gcc/8
+# Bugfix for broken setup script
+ADD fixed-gcc-setup.sh /opt/lcg/gcc/8.2.0-3fa06/x86_64-centos7/setup.sh
 
 # Create the LCG view. Use a fixed location since there is only one
 # release/platform combination. This way, images with different

--- a/centos7-lcg96/Dockerfile
+++ b/centos7-lcg96/Dockerfile
@@ -11,7 +11,7 @@ ENV LCG_RELEASE 96
 ENV LCG_PLATFORM_BASE x86_64-centos7
 ENV LCG_PLATFORM ${LCG_PLATFORM_BASE}-gcc8-opt
 # branch/tag/commit reference for lcgcmake. we need a specific version
-# to be able to create an RPM-base view.
+# to be able to create an RPM-based view.
 ENV LCGCMAKE_REF 16176752
 
 # Add the LCG rpm repository as described here

--- a/centos7-lcg96/fixed-gcc-setup.sh
+++ b/centos7-lcg96/fixed-gcc-setup.sh
@@ -1,0 +1,54 @@
+if [[ -n "$BASH" ]]; then
+    SCRIPT_DIR=$BASH_SOURCE[0]
+else # assume that zsh
+    SCRIPT_DIR=${(%):-%x}
+fi
+
+BASE=$(dirname $(readlink -f $SCRIPT_DIR))
+PLATFORM=x86_64-centos7
+
+
+
+# Source dependencies
+BASE_STACK="${BASE} ${BASE_STACK}" # Add element to stack
+
+depends=$BASE/../../../binutils/2.30/$PLATFORM/setup.sh
+dependshash=$BASE/../../../binutils/2.30-e5b21/$PLATFORM/setup.sh
+if [[ -e "$dependshash" ]]; then
+    source $dependshash
+elif [[ -e "$depends" ]]; then
+    source $depends
+else
+    echo Could not find setup.sh file for package binutils 
+fi
+BASE=$(echo $BASE_STACK | cut -f1 -d' ' ) # Restore BASE 
+
+BASE_STACK=$(echo $BASE_STACK | cut -f2- -d' ') # Remove last element from stack
+
+__PKG_NAME=gcc
+__PKG_VERSION=8.2.0
+__PKG_HASH=3fa06
+
+# Export environmental variables
+export PATH=$BASE/bin:$PATH
+export MANPATH=$BASE/share/man:$MANPATH
+
+if [ -e "${BASE}/lib64" ]; then
+    # Add lib64 if exists
+    export LD_LIBRARY_PATH="$BASE/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+if [ -e "${BASE}/lib" ]; then
+    # Add lib if exists
+    export LD_LIBRARY_PATH="$BASE/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+
+# Export package specific environmental variables
+
+# see https://gcc.gnu.org/onlinedocs/gcc/Environment-Variables.html
+export COMPILER_PATH="${BASE}/libexec/gcc/x86_64-pc-linux-gnu/${__PKG_VERSION}-${__PKG_HASH}"
+export LIBRARY_PATH="${BASE}/lib/gcc/x86_64-pc-linux-gnu/${__PKG_VERSION}-${__PKG_HASH}${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH}"
+export CPLUS_INCLUDE_PATH="${BASE}/include/c++/${__PKG_VERSION}-${__PKG_HASH}:${BASE}/include/c++/${__PKG_VERSION}-${__PKG_HASH}/x86_64-pc-linux-gnu:${BASE}/lib/gcc/x86_64-pc-linux-gnu/${__PKG_VERSION}-${__PKG_HASH}/include:${BASE}/lib/gcc/x86_64-pc-linux-gnu/${__PKG_VERSION}-${__PKG_HASH}/include-fixed"
+
+export FC=`which gfortran`
+export CC=`which gcc`
+export CXX=`which g++`


### PR DESCRIPTION
Replaces the broken `setup.sh` from the RPMs with an updated one that manually sets all required environment variables.