### PR TITLE
Add image for intel oneAPI (SYCL)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -21,6 +21,7 @@ jobs:
           - format10
           - ubuntu1804_cuda
           - ubuntu2004
+          - ubuntu2004_oneapi
     steps:
       - uses: actions/checkout@v2
       - uses: docker/build-push-action@v1

--- a/ubuntu2004_oneapi/Dockerfile
+++ b/ubuntu2004_oneapi/Dockerfile
@@ -8,24 +8,11 @@ LABEL version="1"
 # DEBIAN_FRONTEND ensures non-blocking operation (tzdata is a problem)
 ENV DEBIAN_FRONTEND noninteractive
 
-# install dependencies from the package manager.
+
+
+
 RUN apt-get update -y \
-  && apt-get install -y \
-    build-essential \
-    cmake \
-    curl \
-    git \
-    libboost-dev \
-    libboost-filesystem-dev \
-    libboost-program-options-dev \
-    libboost-test-dev \
-    libeigen3-dev \
-    ninja-build \
-    python3 \
-    python3-dev \
-    python3-pip \
-    rsync \
-    zlib1g-dev \
+  && apt-get install -y gnupg2 curl \
   && apt-get clean -y
 
 RUN curl https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | apt-key add - \
@@ -33,5 +20,14 @@ RUN curl https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCT
 
 RUN apt-get update -y \
   && apt-get install -y \
-    intel-basekit \
+    intel-oneapi-compiler-dpcpp-cpp-2021.1.1 \
+    libstdc++-9-dev \
+    cmake \
+    git \
+    libboost-dev \
+    libboost-filesystem-dev \
+    libboost-program-options-dev \
+    libboost-test-dev \
+    libeigen3-dev \
+    ninja-build \
   && apt-get clean -y

--- a/ubuntu2004_oneapi/Dockerfile
+++ b/ubuntu2004_oneapi/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:20.04
+
+LABEL description="Ubuntu 20.04 with Acts dependencies"
+LABEL maintainer="Moritz Kiehn <msmk@cern.ch>"
+# increase whenever any of the RUN commands change
+LABEL version="1"
+
+# DEBIAN_FRONTEND ensures non-blocking operation (tzdata is a problem)
+ENV DEBIAN_FRONTEND noninteractive
+
+# install dependencies from the package manager.
+RUN apt-get update -y \
+  && apt-get install -y \
+    build-essential \
+    cmake \
+    curl \
+    git \
+    libboost-dev \
+    libboost-filesystem-dev \
+    libboost-program-options-dev \
+    libboost-test-dev \
+    libeigen3-dev \
+    ninja-build \
+    python3 \
+    python3-dev \
+    python3-pip \
+    rsync \
+    zlib1g-dev \
+  && apt-get clean -y
+
+RUN curl https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | apt-key add - \
+  && echo "deb https://apt.repos.intel.com/oneapi all main" > /etc/apt/sources.list.d/oneAPI.list
+
+RUN apt-get update -y \
+  && apt-get install -y \
+    intel-basekit \
+  && apt-get clean -y

--- a/ubuntu2004_oneapi/Dockerfile
+++ b/ubuntu2004_oneapi/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 LABEL description="Ubuntu 20.04 with Acts dependencies"
-LABEL maintainer="Moritz Kiehn <msmk@cern.ch>"
+LABEL maintainer="Paul Gessinger <paul.gessinger@cern.ch>"
 # increase whenever any of the RUN commands change
 LABEL version="1"
 


### PR DESCRIPTION
This uses the same Ubuntu 20.04 image we use anyway. I'm installing Intel's stuff from their APT repo. This *only* clocks in at ~ 3GB, rather than the 6GB of the Intel image. I managed to compile the SYCL plugin with this.