### PR TITLE
Ubuntu 20.04 oneAPI 2021.2 Upgrade, master branch (2021.04.16.)

### DIFF
--- a/ubuntu2004_oneapi/Dockerfile
+++ b/ubuntu2004_oneapi/Dockerfile
@@ -20,7 +20,7 @@ RUN curl https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCT
 
 RUN apt-get update -y \
   && apt-get install -y \
-    intel-oneapi-compiler-dpcpp-cpp-2021.1.1 \
+    intel-oneapi-compiler-dpcpp-cpp-2021.2.0 \
   && apt-get clean -y
 
 RUN apt-get update -y \


### PR DESCRIPTION
Upgraded the ubuntu2004_oneapi image to oneAPI-2021.2.

Besides it being a good idea to upgrade to the recently released version of oneAPI, it is also meant to help with the issue I discovered in https://github.com/acts-project/vecmem/pull/71, and then described in https://github.com/intel/llvm/issues/3549. I.e. I plan to make use of the `SYCL_DEVICE_FILTER` environment variable with the new oneAPI version to not allow the CI tests in the VecMem project to use a CPU device.