### PR TITLE
add image with Ubuntu20.04 and CUDA11 and our deps

### DIFF
--- a/ubuntu2004_cuda/Dockerfile
+++ b/ubuntu2004_cuda/Dockerfile
@@ -1,0 +1,149 @@
+FROM nvidia/cuda:11.4.1-devel-ubuntu20.04
+
+LABEL description="Ubuntu 20.04 with Acts dependencies and CUDA"
+LABEL maintainer="Paul Gessinger <paul.gessinger@cern.ch"
+# increase whenever any of the RUN commands change
+LABEL version="1"
+
+# DEBIAN_FRONTEND ensures non-blocking operation (tzdata is a problem)
+ENV DEBIAN_FRONTEND noninteractive
+
+# install dependencies from the package manager.
+#
+# see also https://root.cern.ch/build-prerequisites
+RUN apt-get update -y \
+  && apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    freeglut3-dev \
+    libboost-dev \
+    libboost-filesystem-dev \
+    libboost-program-options-dev \
+    libboost-test-dev \
+    libexpat-dev \
+    libeigen3-dev \
+    libftgl-dev \
+    libgl2ps-dev \
+    libglew-dev \
+    libgsl-dev \
+    liblz4-dev \
+    liblzma-dev \
+    libpcre3-dev \
+    libtbb-dev \
+    libx11-dev \
+    libxext-dev \
+    libxft-dev \
+    libxpm-dev \
+    libxerces-c-dev \
+    libzstd-dev \
+    ninja-build \
+    python3 \
+    python3-dev \
+    python3-pip \
+    rsync \
+    zlib1g-dev \
+  && apt-get clean -y
+
+# manual builds for hep-specific packages
+ENV GET curl --location --silent --create-dirs
+ENV UNPACK_TO_SRC tar -xz --strip-components=1 --directory src
+ENV PREFIX /usr/local
+
+# CMake 3.17.3 version in APT is too old
+# requires rsync; installation uses `rsync` instead of `install`
+RUN mkdir src \
+  && ${GET} https://github.com/Kitware/CMake/releases/download/v3.17.3/cmake-3.17.3-Linux-x86_64.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && rsync -ruv src/ ${PREFIX} \
+  && cd .. \
+  && rm -rf src
+
+# Geant4
+RUN mkdir src \
+  && ${GET} https://geant4-data.web.cern.ch/geant4-data/releases/geant4.10.06.p01.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DGEANT4_BUILD_CXXSTD=17 \
+    -DGEANT4_INSTALL_DATA=OFF \
+    -DGEANT4_USE_GDML=ON \
+    -DGEANT4_USE_SYSTEM_EXPAT=ON \
+    -DGEANT4_USE_SYSTEM_ZLIB=ON \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# HepMC3
+RUN mkdir src \
+  && ${GET} https://hepmc.web.cern.ch/hepmc/releases/HepMC3-3.2.1.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DHEPMC3_BUILD_STATIC_LIBS=OFF \
+    -DHEPMC3_ENABLE_PYTHON=OFF \
+    -DHEPMC3_ENABLE_ROOTIO=OFF \
+    -DHEPMC3_ENABLE_SEARCH=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# Pythia8
+# requires rsync; installation uses `rsync` instead of `install`
+RUN mkdir src \
+  && ${GET} https://pythia.org/download/pythia82/pythia8244.tgz \
+    | ${UNPACK_TO_SRC} \
+  && cd src \
+  && ./configure --enable-shared --prefix=${PREFIX} \
+  && make -j$(nproc) install \
+  && cd .. \
+  && rm -rf src
+
+# xxHash
+RUN mkdir src \
+  && ${GET} https://github.com/Cyan4973/xxHash/archive/v0.7.3.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src/cmake_unofficial -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+
+# ROOT
+RUN mkdir src \
+  && ${GET} https://root.cern/download/root_v6.20.04.source.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -Dfail-on-missing=ON \
+    -Dgminimal=ON \
+    -Dgdml=ON \
+    -Dopengl=ON \
+    -Dpyroot=ON \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# DD4hep
+# requires Geant4 and ROOT and must come last
+#
+# environment variables needed for DD4hep to find ROOT libraries
+ENV LD_LIBRARY_PATH /usr/local/lib
+ENV PYTHON_PATH /usr/local/lib
+RUN mkdir src \
+  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-11-02.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_PREFIX_PATH=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -DDD4HEP_BUILD_PACKAGES="DDG4" \
+    -DDD4HEP_IGNORE_GEANT4_TLS=ON \
+    -DDD4HEP_USE_GEANT4=ON \
+    -DDD4HEP_USE_XERCESC=ON \
+  && cmake --build build -- install \
+  && rm -rf build src

--- a/ubuntu2004_cuda/Dockerfile
+++ b/ubuntu2004_cuda/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.4.1-devel-ubuntu20.04
+FROM nvidia/cuda:11.3.0-devel-ubuntu20.04
 
 LABEL description="Ubuntu 20.04 with Acts dependencies and CUDA"
 LABEL maintainer="Paul Gessinger <paul.gessinger@cern.ch"


### PR DESCRIPTION
This is again based on nvidias image which I add our dependencies to. I briefly tested this by building the ACTS CUDA plugin, so I think it works.

/cc @beomki-yeo