### PR TITLE
Update CMake version to 3.21.2 for CUDA image

### DIFF
--- a/ubuntu2004_cuda/Dockerfile
+++ b/ubuntu2004_cuda/Dockerfile
@@ -53,7 +53,7 @@ ENV PREFIX /usr/local
 # CMake 3.17.3 version in APT is too old
 # requires rsync; installation uses `rsync` instead of `install`
 RUN mkdir src \
-  && ${GET} https://github.com/Kitware/CMake/releases/download/v3.17.3/cmake-3.17.3-Linux-x86_64.tar.gz \
+  && ${GET} https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-Linux-x86_64.tar.gz \
     | ${UNPACK_TO_SRC} \
   && rsync -ruv src/ ${PREFIX} \
   && cd .. \


### PR DESCRIPTION
So, due to some real mind-boggling stuff we cannot use CMake versions lower than 3.18 to build our C++17 CUDA code because versions 3.17 and lower don't know how to set C++17 on the nvcc executable and therefore just quietly ignore everything. To fix this, I would propose we update the CUDA image to use version 3.21.2 of CMake. This should alleviate the issue and allow acts-project/traccc#78 to progress.