### PR TITLE
Update versions of packages in Ubuntu 20.04 images

### DIFF
--- a/ubuntu2004/Dockerfile
+++ b/ubuntu2004/Dockerfile
@@ -92,9 +92,17 @@ RUN mkdir src \
   && cd .. \
   && rm -rf src
 
+# nlohmann's JSON
+RUN mkdir src \
+  && ${GET} https://github.com/nlohmann/json/archive/refs/tags/v3.10.2.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+  && cmake --build build -- install \
+  && rm -rf build src
+
 # ROOT
 RUN mkdir src \
-  && ${GET} https://root.cern/download/root_v6.20.04.source.tar.gz \
+  && ${GET} https://root.cern/download/root_v6.24.06.source.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
@@ -115,7 +123,7 @@ RUN mkdir src \
 ENV LD_LIBRARY_PATH /usr/local/lib
 ENV PYTHON_PATH /usr/local/lib
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-11-02.tar.gz \
+  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-17.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \

--- a/ubuntu2004_cuda/Dockerfile
+++ b/ubuntu2004_cuda/Dockerfile
@@ -50,10 +50,10 @@ ENV GET curl --location --silent --create-dirs
 ENV UNPACK_TO_SRC tar -xz --strip-components=1 --directory src
 ENV PREFIX /usr/local
 
-# CMake 3.17.3 version in APT is too old
+# CMake 3.16.3 version in APT is too old
 # requires rsync; installation uses `rsync` instead of `install`
 RUN mkdir src \
-  && ${GET} https://github.com/Kitware/CMake/releases/download/v3.17.3/cmake-3.17.3-Linux-x86_64.tar.gz \
+  && ${GET} https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-Linux-x86_64.tar.gz \
     | ${UNPACK_TO_SRC} \
   && rsync -ruv src/ ${PREFIX} \
   && cd .. \
@@ -109,10 +109,17 @@ RUN mkdir src \
   && cmake --build build -- install \
   && rm -rf build src
 
+# nlohmann's JSON
+RUN mkdir src \
+  && ${GET} https://github.com/nlohmann/json/archive/refs/tags/v3.10.2.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+  && cmake --build build -- install \
+  && rm -rf build src
 
 # ROOT
 RUN mkdir src \
-  && ${GET} https://root.cern/download/root_v6.20.04.source.tar.gz \
+  && ${GET} https://root.cern/download/root_v6.24.06.source.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
@@ -133,7 +140,7 @@ RUN mkdir src \
 ENV LD_LIBRARY_PATH /usr/local/lib
 ENV PYTHON_PATH /usr/local/lib
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-11-02.tar.gz \
+  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-17.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
This commit updates the versions of various packages in the Ubuntu 20.04 images. It affects specifically the plain image and the CUDA image; the OneAPI image is not affected. The changes are as follows.

1. The primary goal is to upgrade CMake from version 3.17.3 to version 3.21.2, because this will allow us to build CUDA code with nvcc while adhering to the C++17 standard (see acts-project/traccc#78).
2. Version 6.20.04 of ROOT does not compile with CMake 3.21.2 because it fails to import some Python targets. In order to remedy this (and to look towards the future) I have bumped the ROOT version to 6.24.06.
3. The new version of ROOT requires nlohmann's JSON library to be installed, which I have added to the images accordingly.
4. Finally, DD4hep v01-11-02 cannot be compiled against the new ROOT version, and such I have bumped DD4hep up to v01-17.

In addition, I have fixed a mistake in the comments which Attila found very annoying.

I have built both of these images on my local machine, and the build seems to work well. I am hopeful that they will build successfully in the CI as well!