### PR TITLE
ubuntu1804_cuda_oneapi Image Addition, master branch (2021.10.10.)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -26,14 +26,15 @@ jobs:
           - centos8-lcg101-gcc11
           - format10
           - ubuntu1804_cuda
+          - ubuntu1804_cuda_oneapi
           - ubuntu1804_rocm
           - ubuntu2004
           - ubuntu2004_cuda
           - ubuntu2004_oneapi
-          - ubuntu2004_exatrkx 
+          - ubuntu2004_exatrkx
     steps:
       - uses: actions/checkout@v2
-      - uses: docker/login-action@v1 
+      - uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/ubuntu1804_cuda_oneapi/Dockerfile
+++ b/ubuntu1804_cuda_oneapi/Dockerfile
@@ -17,7 +17,7 @@ RUN git clone https://github.com/intel/llvm.git ${LLVM_SOURCE_DIR} &&          \
        -DCMAKE_INSTALL_LIBDIR=lib                                              \
        -DLLVM_TARGETS_TO_BUILD="X86;NVPTX"                                     \
        -DLLVM_EXTERNAL_PROJECTS="sycl;llvm-spirv;opencl;libdevice;xpti;xptifw" \
-       -DLLVM_ENABLE_PROJECTS="clang;sycl;llvm-spirv;opencl;libdevice;xpti;xptifw;libclc;lld" \
+       -DLLVM_ENABLE_PROJECTS="clang;compiler-rt;sycl;llvm-spirv;opencl;libdevice;xpti;xptifw;libclc;lld" \
        -DLLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR=${LLVM_SOURCE_DIR}/llvm-spirv     \
        -DLLVM_EXTERNAL_SYCL_SOURCE_DIR=${LLVM_SOURCE_DIR}/sycl                 \
        -DLLVM_EXTERNAL_LIBDEVICE_SOURCE_DIR=${LLVM_SOURCE_DIR}/libdevice       \

--- a/ubuntu1804_cuda_oneapi/Dockerfile
+++ b/ubuntu1804_cuda_oneapi/Dockerfile
@@ -1,0 +1,45 @@
+#
+# Image building the Intel LLVM compiler from scratch, with Intel and NVidia
+# backend support.
+#
+
+# Base the image on the repository's ubuntu1804_cuda configuration.
+FROM ghcr.io/acts-project/ubuntu1804_cuda:v17
+
+# Build the Intel DPC++ compiler from source.
+ARG LLVM_VERSION=2021-09
+ARG LLVM_SOURCE_DIR=/root/llvm
+ARG LLVM_BINARY_DIR=/root/build
+RUN git clone https://github.com/intel/llvm.git ${LLVM_SOURCE_DIR} &&          \
+    cd ${LLVM_SOURCE_DIR}/ && git checkout ${LLVM_VERSION} &&                  \
+    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release                                  \
+       -DCMAKE_INSTALL_PREFIX=${PREFIX}                                        \
+       -DCMAKE_INSTALL_LIBDIR=lib                                              \
+       -DLLVM_TARGETS_TO_BUILD="X86;NVPTX"                                     \
+       -DLLVM_EXTERNAL_PROJECTS="sycl;llvm-spirv;opencl;libdevice;xpti;xptifw" \
+       -DLLVM_ENABLE_PROJECTS="clang;sycl;llvm-spirv;opencl;libdevice;xpti;xptifw;libclc;lld" \
+       -DLLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR=${LLVM_SOURCE_DIR}/llvm-spirv     \
+       -DLLVM_EXTERNAL_SYCL_SOURCE_DIR=${LLVM_SOURCE_DIR}/sycl                 \
+       -DLLVM_EXTERNAL_LIBDEVICE_SOURCE_DIR=${LLVM_SOURCE_DIR}/libdevice       \
+       -DLLVM_EXTERNAL_OPENCL_SOURCE_DIR=${LLVM_SOURCE_DIR}/opencl             \
+       -DLLVM_EXTERNAL_XPTI_SOURCE_DIR=${LLVM_SOURCE_DIR}/xpti                 \
+       -DLLVM_EXTERNAL_XPTIFW_SOURCE_DIR=${LLVM_SOURCE_DIR}/xptifw             \
+       -DLIBCLC_TARGETS_TO_BUILD="nvptx64--;nvptx64--nvidiacl"                 \
+       -DLIBCLC_GENERATE_REMANGLED_VARIANTS=ON -DSYCL_BUILD_PI_CUDA=ON         \
+       -DLLVM_BUILD_TOOLS=ON -DSYCL_ENABLE_WERROR=OFF                          \
+       -DSYCL_ENABLE_XPTI_TRACING=ON -DLLVM_ENABLE_LLD=OFF -DLLVM_ENABLE_EH=ON \
+       -DLLVM_ENABLE_PIC=ON -DLLVM_ENABLE_RTTI=ON                              \
+       -DOpenCL_INSTALL_KHRONOS_ICD_LOADER=TRUE                                \
+       -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda                                 \
+       -DCMAKE_PREFIX_PATH=/usr/local/cuda/compat                              \
+       -S ${LLVM_SOURCE_DIR}/llvm/ -B ${LLVM_BINARY_DIR} &&                    \
+    cmake --build ${LLVM_BINARY_DIR} &&                                        \
+    cmake --install ${LLVM_BINARY_DIR} &&                                      \
+    rm -rf ${LLVM_SOURCE_DIR} ${LLVM_BINARY_DIR}
+
+# Set up the correct runtime environment for using the compiler(s).
+ENV CC=${PREFIX}/bin/clang
+ENV CXX=${PREFIX}/bin/clang++
+ENV SYCLCXX="${CXX} -fsycl -fsycl-targets=nvptx64-nvidia-cuda -Wno-linker-warnings"
+ENV CUDAHOSTCXX=${CXX}
+ENV CUDAFLAGS="-allow-unsupported-compiler"


### PR DESCRIPTION
With https://github.com/acts-project/vecmem/pull/127 in the process of fixing a long-standing issue with building NVidia binaries out of that project, it would be a good idea to explicitly test that such issues would not show up in the future.

Unfortunately this is only possible if one builds Intel's compiler by hand. The NVidia/CUDA support is only available with CUDA 10.X, so providing this on top of Ubuntu 20.04 is not the most practical. (It's not impossible, but one must install GCC 8 on Ubuntu 20.04 to make CUDA 10.2 functional. It's a bit too hacky of a setup to use it in the CI.)

The image basically "just" needs 1 more `RUN` step on top of what [ubuntu1804_cuda](ubuntu1804_cuda) already provides. So copy-pasting all of that would be silly. However what I did here is also not brilliant, as setting up the image like this would be pretty awkward for the CI system. I think the best solution would be to rename `ubuntu1804_cuda` to `ubuntu1804_cuda_oneapi`, and just add this one additional `RUN` statement at the end of it.

But I thought I would show the code like this first, and then we can discuss how we may want to go about this.

Pinging @paulgessinger.