### PR TITLE
Add ubuntu1804_rocm_oneapi to the CI, master branch (2022.03.08.)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -28,6 +28,7 @@ jobs:
           - ubuntu1804_cuda
           - ubuntu1804_cuda_oneapi
           - ubuntu1804_rocm
+          - ubuntu1804_rocm_oneapi
           - ubuntu2004
           - ubuntu2004_cuda
           - ubuntu2004_oneapi


### PR DESCRIPTION
Added the build of ubuntu1804_rocm_oneapi to the CI. Since as I found while looking at the build results of #46, we (I...) forgot to add this image to the CI in #45. :frowning: