### PR TITLE
Add lcg path to PATH to discover python

### DIFF
--- a/centos7-lcg100-gcc10/Dockerfile
+++ b/centos7-lcg100-gcc10/Dockerfile
@@ -33,6 +33,8 @@ RUN yum -y install \
     LCG_${LCG_RELEASE}_tbb_2020_U2_${LCG_PLATFORM//-/_}.noarch \
   && yum -y clean all
 
+ENV PATH=/opt/lcg/LCG_100/Python/3.8.6/${LCG_PLATFORM}/bin:$PATH
+
 # Create the LCG view.
 #
 # Use a fixed location since there is only one release/platform combination.


### PR DESCRIPTION
lcgcmake changed their `create_lcg_view.py` script shebang from python to python3 [here](https://gitlab.cern.ch/sft/lcgcmake/-/commit/ce2301be86490eae031c0640e12ec820b82ddde7).

python3 is not on `$PATH` by default, this PR adds that.