### PR TITLE
Add EDM4hep as dependency

### DIFF
--- a/centos7-lcg100-gcc10/Dockerfile
+++ b/centos7-lcg100-gcc10/Dockerfile
@@ -24,6 +24,8 @@ RUN yum -y install \
     LCG_${LCG_RELEASE}_Boost_1.75.0_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_CMake_3.20.0_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_DD4hep_01.16.01_${LCG_PLATFORM//-/_}.noarch \
+    LCG_${LCG_RELEASE}_EDM4hep_00.03_${LCG_PLATFORM//-/_}.noarch \
+    LCG_${LCG_RELEASE}_podio_00.13_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_eigen_3.3.7_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_Geant4_10.07.p01_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_hepmc3_3.2.3_${LCG_PLATFORM//-/_}.noarch \

--- a/centos7-lcg101-gcc11/Dockerfile
+++ b/centos7-lcg101-gcc11/Dockerfile
@@ -23,6 +23,8 @@ RUN yum -y install \
     LCG_${LCG_RELEASE}_Boost_1.77.0_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_CMake_3.20.0_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_DD4hep_01.18_${LCG_PLATFORM//-/_}.noarch \
+    LCG_${LCG_RELEASE}_EDM4hep_00.03_${LCG_PLATFORM//-/_}.noarch \
+    LCG_${LCG_RELEASE}_podio_00.13_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_eigen_3.3.7_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_Geant4_10.07.p02_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_hepmc3_3.2.4_${LCG_PLATFORM//-/_}.noarch \

--- a/centos8-lcg100-gcc10/Dockerfile
+++ b/centos8-lcg100-gcc10/Dockerfile
@@ -26,6 +26,8 @@ RUN dnf install -y https://linuxsoft.cern.ch/wlcg/centos8/x86_64/wlcg-repo-1.0.0
     LCG_${LCG_RELEASE}_Boost_1.75.0_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_CMake_3.20.0_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_DD4hep_01.16.01_${LCG_PLATFORM//-/_}.noarch \
+    LCG_${LCG_RELEASE}_EDM4hep_00.03_${LCG_PLATFORM//-/_}.noarch \
+    LCG_${LCG_RELEASE}_podio_00.13_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_eigen_3.3.7_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_Geant4_10.07.p01_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_hepmc3_3.2.3_${LCG_PLATFORM//-/_}.noarch \

--- a/centos8-lcg101-gcc11/Dockerfile
+++ b/centos8-lcg101-gcc11/Dockerfile
@@ -26,6 +26,8 @@ RUN dnf install -y https://linuxsoft.cern.ch/wlcg/centos8/x86_64/wlcg-repo-1.0.0
     LCG_${LCG_RELEASE}_Boost_1.77.0_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_CMake_3.20.0_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_DD4hep_01.18_${LCG_PLATFORM//-/_}.noarch \
+    LCG_${LCG_RELEASE}_EDM4hep_00.03_${LCG_PLATFORM//-/_}.noarch \
+    LCG_${LCG_RELEASE}_podio_00.13_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_eigen_3.3.7_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_Geant4_10.07.p02_${LCG_PLATFORM//-/_}.noarch \
     LCG_${LCG_RELEASE}_hepmc3_3.2.4_${LCG_PLATFORM//-/_}.noarch \

--- a/ubuntu1804_cuda/Dockerfile
+++ b/ubuntu1804_cuda/Dockerfile
@@ -164,7 +164,27 @@ RUN mkdir src \
   && cmake --build build -- install \
   && rm -rf build src
 
+# podio
+RUN mkdir src \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -USE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src
 
-
-
-
+# EDM4hep
+RUN pip3 install jinja2 pyyaml \
+  && mkdir src \
+  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-01.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -DUSE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src

--- a/ubuntu1804_rocm/Dockerfile
+++ b/ubuntu1804_rocm/Dockerfile
@@ -173,3 +173,28 @@ RUN mkdir src \
     -DDD4HEP_USE_XERCESC=ON \
   && cmake --build build -- install \
   && rm -rf build src
+
+# podio
+RUN mkdir src \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -USE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# EDM4hep
+RUN pip3 install jinja2 pyyaml \
+  && mkdir src \
+  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-01.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -DUSE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src

--- a/ubuntu2004/Dockerfile
+++ b/ubuntu2004/Dockerfile
@@ -98,6 +98,8 @@ RUN mkdir src \
   && ${GET} https://github.com/nlohmann/json/archive/refs/tags/v3.10.2.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DJSON_BuildTests=OFF \
   && cmake --build build -- install \
   && rm -rf build src
 

--- a/ubuntu2004/Dockerfile
+++ b/ubuntu2004/Dockerfile
@@ -138,4 +138,29 @@ RUN mkdir src \
     -DDD4HEP_USE_XERCESC=ON \
   && cmake --build build -- install
 
+# podio
+RUN mkdir src \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -USE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# EDM4hep
+RUN pip3 install jinja2 pyyaml \
+  && mkdir src \
+  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-01.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -DUSE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src
+
 COPY download_geant4_data.sh /usr/local/bin

--- a/ubuntu2004/Dockerfile
+++ b/ubuntu2004/Dockerfile
@@ -136,7 +136,8 @@ RUN mkdir src \
     -DDD4HEP_IGNORE_GEANT4_TLS=ON \
     -DDD4HEP_USE_GEANT4=ON \
     -DDD4HEP_USE_XERCESC=ON \
-  && cmake --build build -- install
+  && cmake --build build -- install \
+  && rm -rf build src
 
 # podio
 RUN mkdir src \

--- a/ubuntu2004_cuda/Dockerfile
+++ b/ubuntu2004_cuda/Dockerfile
@@ -155,3 +155,28 @@ RUN mkdir src \
     -DDD4HEP_USE_XERCESC=ON \
   && cmake --build build -- install \
   && rm -rf build src
+
+# podio
+RUN mkdir src \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -USE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# EDM4hep
+RUN pip3 install jinja2 pyyaml \
+  && mkdir src \
+  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-01.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -DUSE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src

--- a/ubuntu2004_cuda/Dockerfile
+++ b/ubuntu2004_cuda/Dockerfile
@@ -115,6 +115,8 @@ RUN mkdir src \
   && ${GET} https://github.com/nlohmann/json/archive/refs/tags/v3.10.2.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DJSON_BuildTests=OFF \
   && cmake --build build -- install \
   && rm -rf build src
 

--- a/ubuntu2004_exatrkx/Dockerfile
+++ b/ubuntu2004_exatrkx/Dockerfile
@@ -136,3 +136,28 @@ RUN git clone https://github.com/microsoft/onnxruntime src \
       CMAKE_CUDA_ARCHITECTURES=${CUDA_ARCH} \
   && cmake --build build/MinSizeRel -- install \
   && rm -rf build src
+
+# podio
+RUN mkdir src \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -USE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# EDM4hep
+RUN pip3 install jinja2 pyyaml \
+  && mkdir src \
+  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-01.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -DUSE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src

--- a/ubuntu2004_exatrkx/Dockerfile
+++ b/ubuntu2004_exatrkx/Dockerfile
@@ -138,28 +138,3 @@ RUN git clone https://github.com/microsoft/onnxruntime src \
       CMAKE_CUDA_ARCHITECTURES=${CUDA_ARCH} \
   && cmake --build build/MinSizeRel -- install \
   && rm -rf build src
-
-# podio
-RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DBUILD_TESTING=OFF \
-    -USE_EXTERNAL_CATCH2=OFF \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# EDM4hep
-RUN pip3 install jinja2 pyyaml \
-  && mkdir src \
-  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-01.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DBUILD_TESTING=OFF \
-    -DUSE_EXTERNAL_CATCH2=OFF \
-  && cmake --build build -- install \
-  && rm -rf build src

--- a/ubuntu2004_exatrkx/Dockerfile
+++ b/ubuntu2004_exatrkx/Dockerfile
@@ -76,7 +76,9 @@ RUN mkdir -p src \
 RUN mkdir src \
   && ${GET} https://github.com/nlohmann/json/archive/refs/tags/v3.10.2.tar.gz \
     | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja -DJSON_BuildTests=OFF \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DJSON_BuildTests=OFF \
   && cmake --build build -- install \
   && rm -rf build src
 

--- a/ubuntu2004_oneapi/Dockerfile
+++ b/ubuntu2004_oneapi/Dockerfile
@@ -174,3 +174,28 @@ RUN mkdir src \
     -DDD4HEP_USE_XERCESC=ON \
   && cmake --build build -- install \
   && rm -rf build src
+
+# podio
+RUN mkdir src \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -USE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# EDM4hep
+RUN pip3 install jinja2 pyyaml \
+  && mkdir src \
+  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-01.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -DUSE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src

--- a/ubuntu2004_oneapi/Dockerfile
+++ b/ubuntu2004_oneapi/Dockerfile
@@ -24,8 +24,6 @@ RUN apt-get update -y \
   && apt-get clean -y
 
 # Set up the environment variables compelling CMake to use the Intel compilers.
-ENV PATH "/opt/intel/oneapi/compiler/2022.0.2/linux/bin:${PATH}"
-ENV LD_LIBRARY_PATH "/opt/intel/oneapi/compiler/2022.0.2/linux/compiler/lib/intel64:${LD_LIBRARY_PATH}"
 ENV CC icx
 ENV CXX icpx
 ENV SYCLCXX dpcpp
@@ -134,6 +132,8 @@ RUN mkdir src \
     | ${UNPACK_TO_SRC} \
   && . /opt/intel/oneapi/setvars.sh \
   && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DJSON_BuildTests=OFF \
   && cmake --build build -- install \
   && rm -rf build src
 
@@ -181,6 +181,7 @@ RUN mkdir src \
 RUN mkdir src \
   && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
     | ${UNPACK_TO_SRC} \
+  && . /opt/intel/oneapi/setvars.sh \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
@@ -194,6 +195,7 @@ RUN pip3 install jinja2 pyyaml \
   && mkdir src \
   && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-01.tar.gz \
     | ${UNPACK_TO_SRC} \
+  && . /opt/intel/oneapi/setvars.sh \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \

--- a/ubuntu2004_oneapi/Dockerfile
+++ b/ubuntu2004_oneapi/Dockerfile
@@ -24,6 +24,8 @@ RUN apt-get update -y \
   && apt-get clean -y
 
 # Set up the environment variables compelling CMake to use the Intel compilers.
+ENV PATH "/opt/intel/oneapi/compiler/2022.0.2/linux/bin:${PATH}"
+ENV LD_LIBRARY_PATH "/opt/intel/oneapi/compiler/2022.0.2/linux/compiler/lib/intel64:${LD_LIBRARY_PATH}"
 ENV CC icx
 ENV CXX icpx
 ENV SYCLCXX dpcpp


### PR DESCRIPTION
EDM4hep is a future optional dependency of Acts. Putting the dependency into the docker images for now to save build time in the Acts CI

also did some minor reformatting and adopted the json build to be consistent across the different Dockerfiles