### PR TITLE
EDM4hep is required by DD4hep

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       matrix:
         context:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       matrix:
         context:

--- a/centos7-lcg100-gcc10/Dockerfile
+++ b/centos7-lcg100-gcc10/Dockerfile
@@ -58,4 +58,4 @@ RUN git clone https://gitlab.cern.ch/sft/lcgcmake.git lcgcmake \
   && rm -rf lcgcmake
 
 # LCIO sets it's root include path for cmake absolute, remedy this with a symlink
-RUN ln -s /opt/lcg/LCIO /LCIO 
+RUN ln -s /opt/lcg/LCIO /LCIO

--- a/centos8-lcg101-gcc11/Dockerfile
+++ b/centos8-lcg101-gcc11/Dockerfile
@@ -58,4 +58,4 @@ RUN git clone https://gitlab.cern.ch/sft/lcgcmake.git lcgcmake \
   && rm -rf lcgcmake
 
 # LCIO sets it's root include path for cmake absolute, remedy this with a symlink
-RUN ln -s /opt/lcg/LCIO /LCIO 
+RUN ln -s /opt/lcg/LCIO /LCIO

--- a/ubuntu1804_cuda/Dockerfile
+++ b/ubuntu1804_cuda/Dockerfile
@@ -142,12 +142,37 @@ RUN mkdir src \
   && cmake --build build -- install \
   && rm -rf build src
 
-# DD4hep
-# requires Geant4 and ROOT and must come last
-#
-# environment variables needed for DD4hep to find ROOT libraries
+# environment variables needed to find ROOT libraries
 ENV LD_LIBRARY_PATH /usr/local/lib
 ENV PYTHON_PATH /usr/local/lib
+
+# podio
+RUN mkdir src \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-13-02.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -USE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# EDM4hep
+RUN pip3 install jinja2 pyyaml \
+  && mkdir src \
+  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-03-01.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -DUSE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# DD4hep
+# requires Geant4 and ROOT and must come last
 RUN mkdir src \
   && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-11-02.tar.gz \
     | ${UNPACK_TO_SRC} \
@@ -161,30 +186,6 @@ RUN mkdir src \
     -DDD4HEP_IGNORE_GEANT4_TLS=ON \
     -DDD4HEP_USE_GEANT4=ON \
     -DDD4HEP_USE_XERCESC=ON \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# podio
-RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DBUILD_TESTING=OFF \
-    -USE_EXTERNAL_CATCH2=OFF \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# EDM4hep
-RUN pip3 install jinja2 pyyaml \
-  && mkdir src \
-  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-01.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DBUILD_TESTING=OFF \
-    -DUSE_EXTERNAL_CATCH2=OFF \
+    -DDD4HEP_USE_EDM4HEP=ON \
   && cmake --build build -- install \
   && rm -rf build src

--- a/ubuntu1804_cuda/Dockerfile
+++ b/ubuntu1804_cuda/Dockerfile
@@ -148,7 +148,7 @@ ENV PYTHON_PATH /usr/local/lib
 
 # podio
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-13-02.tar.gz \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
@@ -161,7 +161,7 @@ RUN mkdir src \
 # EDM4hep
 RUN pip3 install jinja2 pyyaml \
   && mkdir src \
-  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-03-01.tar.gz \
+  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-02.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
@@ -174,7 +174,7 @@ RUN pip3 install jinja2 pyyaml \
 # DD4hep
 # requires Geant4 and ROOT and must come last
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-11-02.tar.gz \
+  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-20-02.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \

--- a/ubuntu1804_rocm/Dockerfile
+++ b/ubuntu1804_rocm/Dockerfile
@@ -152,12 +152,37 @@ RUN mkdir src \
   && cmake --build build -- install \
   && rm -rf build src
 
-# DD4hep
-# requires Geant4 and ROOT and must come last
-#
-# environment variables needed for DD4hep to find ROOT libraries
+# environment variables needed to find ROOT libraries
 ENV LD_LIBRARY_PATH /usr/local/lib
 ENV PYTHON_PATH /usr/local/lib
+
+# podio
+RUN mkdir src \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-13-02.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -USE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# EDM4hep
+RUN pip3 install jinja2 pyyaml \
+  && mkdir src \
+  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-03-01.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -DUSE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# DD4hep
+# requires Geant4 and ROOT and must come last
 RUN mkdir src \
   && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-11-02.tar.gz \
     | ${UNPACK_TO_SRC} \
@@ -171,30 +196,6 @@ RUN mkdir src \
     -DDD4HEP_IGNORE_GEANT4_TLS=ON \
     -DDD4HEP_USE_GEANT4=ON \
     -DDD4HEP_USE_XERCESC=ON \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# podio
-RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DBUILD_TESTING=OFF \
-    -USE_EXTERNAL_CATCH2=OFF \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# EDM4hep
-RUN pip3 install jinja2 pyyaml \
-  && mkdir src \
-  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-01.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DBUILD_TESTING=OFF \
-    -DUSE_EXTERNAL_CATCH2=OFF \
+    -DDD4HEP_USE_EDM4HEP=ON \
   && cmake --build build -- install \
   && rm -rf build src

--- a/ubuntu1804_rocm/Dockerfile
+++ b/ubuntu1804_rocm/Dockerfile
@@ -158,7 +158,7 @@ ENV PYTHON_PATH /usr/local/lib
 
 # podio
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-13-02.tar.gz \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
@@ -171,7 +171,7 @@ RUN mkdir src \
 # EDM4hep
 RUN pip3 install jinja2 pyyaml \
   && mkdir src \
-  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-03-01.tar.gz \
+  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-02.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
@@ -184,7 +184,7 @@ RUN pip3 install jinja2 pyyaml \
 # DD4hep
 # requires Geant4 and ROOT and must come last
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-11-02.tar.gz \
+  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-20-02.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \

--- a/ubuntu2004/Dockerfile
+++ b/ubuntu2004/Dockerfile
@@ -137,7 +137,7 @@ ENV PYTHON_PATH /usr/local/lib
 
 # podio
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-13-01.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \

--- a/ubuntu2004/Dockerfile
+++ b/ubuntu2004/Dockerfile
@@ -137,7 +137,7 @@ ENV PYTHON_PATH /usr/local/lib
 
 # podio
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-13-02.tar.gz \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-13.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
@@ -150,7 +150,7 @@ RUN mkdir src \
 # EDM4hep
 RUN pip3 install jinja2 pyyaml \
   && mkdir src \
-  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-03-01.tar.gz \
+  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-03.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \

--- a/ubuntu2004/Dockerfile
+++ b/ubuntu2004/Dockerfile
@@ -150,7 +150,7 @@ RUN mkdir src \
 # EDM4hep
 RUN pip3 install jinja2 pyyaml \
   && mkdir src \
-  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-01.tar.gz \
+  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-03-01.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \

--- a/ubuntu2004/Dockerfile
+++ b/ubuntu2004/Dockerfile
@@ -131,6 +131,10 @@ RUN mkdir src \
   && cmake --build build -- install \
   && rm -rf build src
 
+# environment variables needed to find ROOT libraries
+ENV LD_LIBRARY_PATH /usr/local/lib
+ENV PYTHON_PATH /usr/local/lib
+
 # podio
 RUN mkdir src \
   && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
@@ -138,7 +142,6 @@ RUN mkdir src \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DCMAKE_PREFIX_PATH=${PREFIX} \
     -DBUILD_TESTING=OFF \
     -USE_EXTERNAL_CATCH2=OFF \
   && cmake --build build -- install \
@@ -152,7 +155,6 @@ RUN pip3 install jinja2 pyyaml \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DCMAKE_PREFIX_PATH=${PREFIX} \
     -DBUILD_TESTING=OFF \
     -DUSE_EXTERNAL_CATCH2=OFF \
   && cmake --build build -- install \
@@ -160,10 +162,6 @@ RUN pip3 install jinja2 pyyaml \
 
 # DD4hep
 # requires Geant4 and ROOT and must come last
-#
-# environment variables needed for DD4hep to find ROOT libraries
-ENV LD_LIBRARY_PATH /usr/local/lib
-ENV PYTHON_PATH /usr/local/lib
 RUN mkdir src \
   && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-17.tar.gz \
     | ${UNPACK_TO_SRC} \

--- a/ubuntu2004/Dockerfile
+++ b/ubuntu2004/Dockerfile
@@ -131,28 +131,6 @@ RUN mkdir src \
   && cmake --build build -- install \
   && rm -rf build src
 
-# DD4hep
-# requires Geant4 and ROOT and must come last
-#
-# environment variables needed for DD4hep to find ROOT libraries
-ENV LD_LIBRARY_PATH /usr/local/lib
-ENV PYTHON_PATH /usr/local/lib
-RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-17.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_CXX_STANDARD=17 \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DCMAKE_PREFIX_PATH=${PREFIX} \
-    -DBUILD_TESTING=OFF \
-    -DDD4HEP_BUILD_PACKAGES="DDG4 DDDetectors DDRec" \
-    -DDD4HEP_IGNORE_GEANT4_TLS=ON \
-    -DDD4HEP_USE_GEANT4=ON \
-    -DDD4HEP_USE_XERCESC=ON \
-  && cmake --build build -- install \
-  && rm -rf build src
-
 # podio
 RUN mkdir src \
   && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
@@ -175,6 +153,29 @@ RUN pip3 install jinja2 pyyaml \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
     -DBUILD_TESTING=OFF \
     -DUSE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# DD4hep
+# requires Geant4 and ROOT and must come last
+#
+# environment variables needed for DD4hep to find ROOT libraries
+ENV LD_LIBRARY_PATH /usr/local/lib
+ENV PYTHON_PATH /usr/local/lib
+RUN mkdir src \
+  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-17.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_PREFIX_PATH=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -DDD4HEP_BUILD_PACKAGES="DDG4 DDDetectors DDRec" \
+    -DDD4HEP_IGNORE_GEANT4_TLS=ON \
+    -DDD4HEP_USE_GEANT4=ON \
+    -DDD4HEP_USE_XERCESC=ON \
+    -DDD4HEP_USE_EDM4HEP=ON \
   && cmake --build build -- install \
   && rm -rf build src
 

--- a/ubuntu2004/Dockerfile
+++ b/ubuntu2004/Dockerfile
@@ -137,7 +137,7 @@ ENV PYTHON_PATH /usr/local/lib
 
 # podio
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-13.tar.gz \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-02.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
@@ -150,7 +150,7 @@ RUN mkdir src \
 # EDM4hep
 RUN pip3 install jinja2 pyyaml \
   && mkdir src \
-  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-03.tar.gz \
+  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-02.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
@@ -163,7 +163,7 @@ RUN pip3 install jinja2 pyyaml \
 # DD4hep
 # requires Geant4 and ROOT and must come last
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-17.tar.gz \
+  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-20-02.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \

--- a/ubuntu2004/Dockerfile
+++ b/ubuntu2004/Dockerfile
@@ -137,7 +137,7 @@ ENV PYTHON_PATH /usr/local/lib
 
 # podio
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-13-01.tar.gz \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-13-02.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \

--- a/ubuntu2004/Dockerfile
+++ b/ubuntu2004/Dockerfile
@@ -138,6 +138,7 @@ RUN mkdir src \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_PREFIX_PATH=${PREFIX} \
     -DBUILD_TESTING=OFF \
     -USE_EXTERNAL_CATCH2=OFF \
   && cmake --build build -- install \
@@ -151,6 +152,7 @@ RUN pip3 install jinja2 pyyaml \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_PREFIX_PATH=${PREFIX} \
     -DBUILD_TESTING=OFF \
     -DUSE_EXTERNAL_CATCH2=OFF \
   && cmake --build build -- install \

--- a/ubuntu2004/Dockerfile
+++ b/ubuntu2004/Dockerfile
@@ -137,7 +137,7 @@ ENV PYTHON_PATH /usr/local/lib
 
 # podio
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-02.tar.gz \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \

--- a/ubuntu2004_cuda/Dockerfile
+++ b/ubuntu2004_cuda/Dockerfile
@@ -136,28 +136,6 @@ RUN mkdir src \
   && cmake --build build -- install \
   && rm -rf build src
 
-# DD4hep
-# requires Geant4 and ROOT and must come last
-#
-# environment variables needed for DD4hep to find ROOT libraries
-ENV LD_LIBRARY_PATH /usr/local/lib
-ENV PYTHON_PATH /usr/local/lib
-RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-17.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_CXX_STANDARD=17 \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DCMAKE_PREFIX_PATH=${PREFIX} \
-    -DBUILD_TESTING=OFF \
-    -DDD4HEP_BUILD_PACKAGES="DDG4" \
-    -DDD4HEP_IGNORE_GEANT4_TLS=ON \
-    -DDD4HEP_USE_GEANT4=ON \
-    -DDD4HEP_USE_XERCESC=ON \
-  && cmake --build build -- install \
-  && rm -rf build src
-
 # podio
 RUN mkdir src \
   && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
@@ -180,5 +158,28 @@ RUN pip3 install jinja2 pyyaml \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
     -DBUILD_TESTING=OFF \
     -DUSE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# DD4hep
+# requires Geant4 and ROOT and must come last
+#
+# environment variables needed for DD4hep to find ROOT libraries
+ENV LD_LIBRARY_PATH /usr/local/lib
+ENV PYTHON_PATH /usr/local/lib
+RUN mkdir src \
+  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-17.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_PREFIX_PATH=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -DDD4HEP_BUILD_PACKAGES="DDG4" \
+    -DDD4HEP_IGNORE_GEANT4_TLS=ON \
+    -DDD4HEP_USE_GEANT4=ON \
+    -DDD4HEP_USE_XERCESC=ON \
+    -DDD4HEP_USE_EDM4HEP=ON \
   && cmake --build build -- install \
   && rm -rf build src

--- a/ubuntu2004_cuda/Dockerfile
+++ b/ubuntu2004_cuda/Dockerfile
@@ -170,7 +170,7 @@ RUN pip3 install jinja2 pyyaml \
 # DD4hep
 # requires Geant4 and ROOT and must come last
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-17.tar.gz \
+  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-20-02.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \

--- a/ubuntu2004_cuda/Dockerfile
+++ b/ubuntu2004_cuda/Dockerfile
@@ -156,7 +156,7 @@ RUN mkdir src \
 # EDM4hep
 RUN pip3 install jinja2 pyyaml \
   && mkdir src \
-  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-01.tar.gz \
+  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-03-01.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \

--- a/ubuntu2004_cuda/Dockerfile
+++ b/ubuntu2004_cuda/Dockerfile
@@ -136,6 +136,10 @@ RUN mkdir src \
   && cmake --build build -- install \
   && rm -rf build src
 
+# environment variables needed to find ROOT libraries
+ENV LD_LIBRARY_PATH /usr/local/lib
+ENV PYTHON_PATH /usr/local/lib
+
 # podio
 RUN mkdir src \
   && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
@@ -165,10 +169,6 @@ RUN pip3 install jinja2 pyyaml \
 
 # DD4hep
 # requires Geant4 and ROOT and must come last
-#
-# environment variables needed for DD4hep to find ROOT libraries
-ENV LD_LIBRARY_PATH /usr/local/lib
-ENV PYTHON_PATH /usr/local/lib
 RUN mkdir src \
   && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-17.tar.gz \
     | ${UNPACK_TO_SRC} \

--- a/ubuntu2004_cuda/Dockerfile
+++ b/ubuntu2004_cuda/Dockerfile
@@ -142,7 +142,7 @@ ENV PYTHON_PATH /usr/local/lib
 
 # podio
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-13-02.tar.gz \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
@@ -156,7 +156,7 @@ RUN mkdir src \
 # EDM4hep
 RUN pip3 install jinja2 pyyaml \
   && mkdir src \
-  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-03-01.tar.gz \
+  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-02.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \

--- a/ubuntu2004_cuda/Dockerfile
+++ b/ubuntu2004_cuda/Dockerfile
@@ -142,7 +142,7 @@ ENV PYTHON_PATH /usr/local/lib
 
 # podio
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-13-01.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \

--- a/ubuntu2004_cuda/Dockerfile
+++ b/ubuntu2004_cuda/Dockerfile
@@ -143,6 +143,7 @@ RUN mkdir src \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_PREFIX_PATH=${PREFIX} \
     -DBUILD_TESTING=OFF \
     -USE_EXTERNAL_CATCH2=OFF \
   && cmake --build build -- install \
@@ -156,6 +157,7 @@ RUN pip3 install jinja2 pyyaml \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_PREFIX_PATH=${PREFIX} \
     -DBUILD_TESTING=OFF \
     -DUSE_EXTERNAL_CATCH2=OFF \
   && cmake --build build -- install \

--- a/ubuntu2004_cuda/Dockerfile
+++ b/ubuntu2004_cuda/Dockerfile
@@ -142,7 +142,7 @@ ENV PYTHON_PATH /usr/local/lib
 
 # podio
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-13-01.tar.gz \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-13-02.tar.gz \
     | ${UNPACK_TO_SRC} \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \

--- a/ubuntu2004_oneapi/Dockerfile
+++ b/ubuntu2004_oneapi/Dockerfile
@@ -160,7 +160,7 @@ ENV PYTHON_PATH /usr/local/lib
 
 # podio
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-13-02.tar.gz \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
     | ${UNPACK_TO_SRC} \
   && . /opt/intel/oneapi/setvars.sh \
   && cmake -B build -S src -GNinja \
@@ -175,7 +175,7 @@ RUN mkdir src \
 # EDM4hep
 RUN pip3 install jinja2 pyyaml \
   && mkdir src \
-  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-03-01.tar.gz \
+  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-02.tar.gz \
     | ${UNPACK_TO_SRC} \
   && . /opt/intel/oneapi/setvars.sh \
   && cmake -B build -S src -GNinja \

--- a/ubuntu2004_oneapi/Dockerfile
+++ b/ubuntu2004_oneapi/Dockerfile
@@ -162,6 +162,7 @@ RUN mkdir src \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_PREFIX_PATH=${PREFIX} \
     -DBUILD_TESTING=OFF \
     -USE_EXTERNAL_CATCH2=OFF \
   && cmake --build build -- install \
@@ -176,6 +177,7 @@ RUN pip3 install jinja2 pyyaml \
   && cmake -B build -S src -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_PREFIX_PATH=${PREFIX} \
     -DBUILD_TESTING=OFF \
     -DUSE_EXTERNAL_CATCH2=OFF \
   && cmake --build build -- install \

--- a/ubuntu2004_oneapi/Dockerfile
+++ b/ubuntu2004_oneapi/Dockerfile
@@ -154,6 +154,10 @@ RUN mkdir src \
   && cmake --build build -- install \
   && rm -rf build src
 
+# environment variables needed for DD4hep to find ROOT libraries
+ENV LD_LIBRARY_PATH /usr/local/lib
+ENV PYTHON_PATH /usr/local/lib
+
 # podio
 RUN mkdir src \
   && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
@@ -185,10 +189,6 @@ RUN pip3 install jinja2 pyyaml \
 
 # DD4hep
 # requires Geant4 and ROOT and must come last
-#
-# environment variables needed for DD4hep to find ROOT libraries
-ENV LD_LIBRARY_PATH /usr/local/lib
-ENV PYTHON_PATH /usr/local/lib
 RUN mkdir src \
   && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-17.tar.gz \
     | ${UNPACK_TO_SRC} \

--- a/ubuntu2004_oneapi/Dockerfile
+++ b/ubuntu2004_oneapi/Dockerfile
@@ -190,7 +190,7 @@ RUN pip3 install jinja2 pyyaml \
 # DD4hep
 # requires Geant4 and ROOT and must come last
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-17.tar.gz \
+  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-20-02.tar.gz \
     | ${UNPACK_TO_SRC} \
   && . /opt/intel/oneapi/setvars.sh \
   && cmake -B build -S src -GNinja \

--- a/ubuntu2004_oneapi/Dockerfile
+++ b/ubuntu2004_oneapi/Dockerfile
@@ -154,29 +154,6 @@ RUN mkdir src \
   && cmake --build build -- install \
   && rm -rf build src
 
-# DD4hep
-# requires Geant4 and ROOT and must come last
-#
-# environment variables needed for DD4hep to find ROOT libraries
-ENV LD_LIBRARY_PATH /usr/local/lib
-ENV PYTHON_PATH /usr/local/lib
-RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-17.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && . /opt/intel/oneapi/setvars.sh \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_CXX_STANDARD=17 \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DCMAKE_PREFIX_PATH=${PREFIX} \
-    -DBUILD_TESTING=OFF \
-    -DDD4HEP_BUILD_PACKAGES="DDG4 DDDetectors DDRec" \
-    -DDD4HEP_IGNORE_GEANT4_TLS=ON \
-    -DDD4HEP_USE_GEANT4=ON \
-    -DDD4HEP_USE_XERCESC=ON \
-  && cmake --build build -- install \
-  && rm -rf build src
-
 # podio
 RUN mkdir src \
   && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
@@ -201,5 +178,29 @@ RUN pip3 install jinja2 pyyaml \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
     -DBUILD_TESTING=OFF \
     -DUSE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# DD4hep
+# requires Geant4 and ROOT and must come last
+#
+# environment variables needed for DD4hep to find ROOT libraries
+ENV LD_LIBRARY_PATH /usr/local/lib
+ENV PYTHON_PATH /usr/local/lib
+RUN mkdir src \
+  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-17.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && . /opt/intel/oneapi/setvars.sh \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_PREFIX_PATH=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -DDD4HEP_BUILD_PACKAGES="DDG4 DDDetectors DDRec" \
+    -DDD4HEP_IGNORE_GEANT4_TLS=ON \
+    -DDD4HEP_USE_GEANT4=ON \
+    -DDD4HEP_USE_XERCESC=ON \
+    -DDD4HEP_USE_EDM4HEP=ON \
   && cmake --build build -- install \
   && rm -rf build src

--- a/ubuntu2004_oneapi/Dockerfile
+++ b/ubuntu2004_oneapi/Dockerfile
@@ -175,7 +175,7 @@ RUN mkdir src \
 # EDM4hep
 RUN pip3 install jinja2 pyyaml \
   && mkdir src \
-  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-01.tar.gz \
+  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-03-01.tar.gz \
     | ${UNPACK_TO_SRC} \
   && . /opt/intel/oneapi/setvars.sh \
   && cmake -B build -S src -GNinja \

--- a/ubuntu2004_oneapi/Dockerfile
+++ b/ubuntu2004_oneapi/Dockerfile
@@ -160,7 +160,7 @@ ENV PYTHON_PATH /usr/local/lib
 
 # podio
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-13-01.tar.gz \
     | ${UNPACK_TO_SRC} \
   && . /opt/intel/oneapi/setvars.sh \
   && cmake -B build -S src -GNinja \

--- a/ubuntu2004_oneapi/Dockerfile
+++ b/ubuntu2004_oneapi/Dockerfile
@@ -160,7 +160,7 @@ ENV PYTHON_PATH /usr/local/lib
 
 # podio
 RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-13-01.tar.gz \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-13-02.tar.gz \
     | ${UNPACK_TO_SRC} \
   && . /opt/intel/oneapi/setvars.sh \
   && cmake -B build -S src -GNinja \


### PR DESCRIPTION
rearrange build chain because EDM4hep is required by DD4hep