### PR TITLE
prevent everything built twice

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,6 +1,8 @@
 name: Build images
 
 on:
+  pull_request:
+    types: [opened, reopened]
   push:
     branches:
       - '**'

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,7 +1,6 @@
 name: Build images
 
 on:
-  pull_request:
   push:
     branches:
       - '**'


### PR DESCRIPTION
There is `pull_request:` as well as `push:` specified in the yaml. However, this triggers the workflow twice on pull requests, since they also count as push. Removal of the `pull_request:` trigger should not affect the functionality.