### PR TITLE
Ubuntu 20.04 CUDA Update, master branch (2022.09.21.)

### DIFF
--- a/ubuntu2004_cuda/Dockerfile
+++ b/ubuntu2004_cuda/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.5.0-devel-ubuntu20.04
+FROM nvidia/cuda:11.6.2-devel-ubuntu20.04
 
 LABEL description="Ubuntu 20.04 with Acts dependencies and CUDA"
 LABEL maintainer="Paul Gessinger <paul.gessinger@cern.ch"


### PR DESCRIPTION
Updated the `ubuntu2004_cuda` image to CUDA 11.6.2. This is a necessary update for building the [2022-06 tag](https://github.com/intel/llvm/tree/2022-06) of the Intel compiler on top of this image. (CUDA 11.5.0 has a weird issue with Clang 15...) Which will come in a follow-up PR, after a new release was built with this update...