### PR TITLE
Update to the 2022-06 tag of intel/llvm, master branch (2022.11.03.)

### DIFF
--- a/ubuntu1804_cuda_oneapi/Dockerfile
+++ b/ubuntu1804_cuda_oneapi/Dockerfile
@@ -4,36 +4,45 @@
 #
 
 # Base the image on the repository's ubuntu1804_cuda configuration.
-FROM ghcr.io/acts-project/ubuntu1804_cuda:v17
+FROM ghcr.io/acts-project/ubuntu1804_cuda:v30
+
+# Grab the patch necessary for Ubuntu 18.04.
+COPY llvm-2022-06-python3.6.patch /root/
 
 # Build the Intel DPC++ compiler from source.
-ARG LLVM_VERSION=2021-09
+ARG LLVM_VERSION=2022-06
 ARG LLVM_SOURCE_DIR=/root/llvm
 ARG LLVM_BINARY_DIR=/root/build
 RUN git clone https://github.com/intel/llvm.git ${LLVM_SOURCE_DIR} &&          \
     cd ${LLVM_SOURCE_DIR}/ && git checkout ${LLVM_VERSION} &&                  \
-    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release                                  \
+    patch -p1 < /root/llvm-2022-06-python3.6.patch &&                          \
+    cmake -DCMAKE_BUILD_TYPE=Release                                           \
        -DCMAKE_INSTALL_PREFIX=${PREFIX}                                        \
-       -DCMAKE_INSTALL_LIBDIR=lib                                              \
+       -DLLVM_ENABLE_ASSERTIONS=ON -DCMAKE_INSTALL_LIBDIR=lib                  \
        -DLLVM_TARGETS_TO_BUILD="X86;NVPTX"                                     \
        -DLLVM_EXTERNAL_PROJECTS="sycl;llvm-spirv;opencl;libdevice;xpti;xptifw" \
-       -DLLVM_ENABLE_PROJECTS="clang;compiler-rt;sycl;llvm-spirv;opencl;libdevice;xpti;xptifw;libclc;lld" \
+       -DLLVM_ENABLE_PROJECTS="clang;compiler-rt;sycl;llvm-spirv;opencl;libdevice;xpti;xptifw;libclc;lld;clang-tools-extra;openmp" \
        -DLLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR=${LLVM_SOURCE_DIR}/llvm-spirv     \
        -DLLVM_EXTERNAL_SYCL_SOURCE_DIR=${LLVM_SOURCE_DIR}/sycl                 \
        -DLLVM_EXTERNAL_LIBDEVICE_SOURCE_DIR=${LLVM_SOURCE_DIR}/libdevice       \
-       -DLLVM_EXTERNAL_OPENCL_SOURCE_DIR=${LLVM_SOURCE_DIR}/opencl             \
        -DLLVM_EXTERNAL_XPTI_SOURCE_DIR=${LLVM_SOURCE_DIR}/xpti                 \
+       -DXPTI_SOURCE_DIR=${LLVM_SOURCE_DIR}/xpti                               \
        -DLLVM_EXTERNAL_XPTIFW_SOURCE_DIR=${LLVM_SOURCE_DIR}/xptifw             \
        -DLIBCLC_TARGETS_TO_BUILD="nvptx64--;nvptx64--nvidiacl"                 \
-       -DLIBCLC_GENERATE_REMANGLED_VARIANTS=ON -DSYCL_BUILD_PI_CUDA=ON         \
+       -DLIBCLC_GENERATE_REMANGLED_VARIANTS=ON                                 \
        -DLLVM_BUILD_TOOLS=ON -DSYCL_ENABLE_WERROR=OFF                          \
-       -DSYCL_ENABLE_XPTI_TRACING=ON -DLLVM_ENABLE_LLD=OFF -DLLVM_ENABLE_EH=ON \
-       -DLLVM_ENABLE_PIC=ON -DLLVM_ENABLE_RTTI=ON                              \
+       -DSYCL_INCLUDE_TESTS=OFF -DLLVM_ENABLE_DOXYGEN=OFF                      \
+       -DLLVM_ENABLE_SPHINX=OFF -DBUILD_SHARED_LIBS=OFF                        \
+       -DSYCL_ENABLE_XPTI_TRACING=ON -DLLVM_ENABLE_LLD=OFF                     \
+       -DLLVM_ENABLE_PIC=ON -DLLVM_ENABLE_RTTI=ON -DXPTI_ENABLE_WERROR=OFF     \
        -DOpenCL_INSTALL_KHRONOS_ICD_LOADER=TRUE                                \
        -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda                                 \
        -DCMAKE_PREFIX_PATH=/usr/local/cuda/compat                              \
+       -DSYCL_ENABLE_PLUGINS="opencl;level_zero;cuda"                          \
        -S ${LLVM_SOURCE_DIR}/llvm/ -B ${LLVM_BINARY_DIR} &&                    \
+    export MAKEFLAGS=-j`nproc` &&                                              \
     cmake --build ${LLVM_BINARY_DIR} &&                                        \
+    cmake --build ${LLVM_BINARY_DIR} --target sycl-toolchain &&                \
     cmake --install ${LLVM_BINARY_DIR} &&                                      \
     rm -rf ${LLVM_SOURCE_DIR} ${LLVM_BINARY_DIR}
 

--- a/ubuntu1804_cuda_oneapi/llvm-2022-06-python3.6.patch
+++ b/ubuntu1804_cuda_oneapi/llvm-2022-06-python3.6.patch
@@ -1,0 +1,37 @@
+diff --git a/sycl/plugins/level_zero/ze_api_generator.py b/sycl/plugins/level_zero/ze_api_generator.py
+index ca70341c93a4..b49060beb7bf 100644
+--- a/sycl/plugins/level_zero/ze_api_generator.py
++++ b/sycl/plugins/level_zero/ze_api_generator.py
+@@ -35,6 +35,6 @@ def extract_ze_apis(header):
+     api.close()
+ 
+ if __name__ == "__main__":
+-    with open(sys.argv[1], 'r') as f:
++    with open(sys.argv[1], 'r', encoding='utf-8') as f:
+         header = f.read()
+         extract_ze_apis(header)
+diff --git a/sycl/tools/sycl-trace/generate_pi_pretty_printers.py b/sycl/tools/sycl-trace/generate_pi_pretty_printers.py
+index 07b0c3a41c94..f290c73414c9 100644
+--- a/sycl/tools/sycl-trace/generate_pi_pretty_printers.py
++++ b/sycl/tools/sycl-trace/generate_pi_pretty_printers.py
+@@ -49,6 +49,6 @@ if __name__ == "__main__":
+     """
+     Usage: python generate_pi_pretty_printers.py path/to/pi.h
+     """
+-    with open(sys.argv[1], 'r') as f:
++    with open(sys.argv[1], 'r', encoding='utf-8') as f:
+         header = f.read()
+         generate_pi_pretty_printers(header)
+diff --git a/sycl/tools/sycl-trace/generate_ze_pretty_printers.py b/sycl/tools/sycl-trace/generate_ze_pretty_printers.py
+index 40d1b600b9c5..f4df492c6ea5 100644
+--- a/sycl/tools/sycl-trace/generate_ze_pretty_printers.py
++++ b/sycl/tools/sycl-trace/generate_ze_pretty_printers.py
+@@ -53,7 +53,7 @@ if __name__ == "__main__":
+     """
+     Usage: python generate_pi_pretty_printers.py path/to/ze_api.h
+     """
+-    with open(sys.argv[1], 'r') as f:
++    with open(sys.argv[1], 'r', encoding='utf-8') as f:
+         header = f.read()
+         generate_ze_pretty_printers(header)
+ 

--- a/ubuntu1804_rocm_oneapi/Dockerfile
+++ b/ubuntu1804_rocm_oneapi/Dockerfile
@@ -4,35 +4,41 @@
 #
 
 # Base the image on the repository's ubuntu1804_rocm configuration.
-FROM ghcr.io/acts-project/ubuntu1804_rocm:v19
+FROM ghcr.io/acts-project/ubuntu1804_rocm:v30
+
+# Grab the patch necessary for Ubuntu 18.04.
+COPY llvm-2022-06-python3.6.patch /root/
 
 # Build the Intel DPC++ compiler from source.
-ARG LLVM_VERSION=sycl-nightly/20220217
+ARG LLVM_VERSION=2022-06
 ARG LLVM_SOURCE_DIR=/root/llvm
 ARG LLVM_BINARY_DIR=/root/build
 RUN git clone https://github.com/intel/llvm.git ${LLVM_SOURCE_DIR} &&          \
     cd ${LLVM_SOURCE_DIR}/ && git checkout ${LLVM_VERSION} &&                  \
-    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release                                  \
+    patch -p1 < /root/llvm-2022-06-python3.6.patch &&                          \
+    cmake -DCMAKE_BUILD_TYPE=Release                                           \
        -DCMAKE_INSTALL_PREFIX=${PREFIX}                                        \
-       -DCMAKE_INSTALL_LIBDIR=lib                                              \
+       -DLLVM_ENABLE_ASSERTIONS=ON -DCMAKE_INSTALL_LIBDIR=lib                  \
        -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU"                                    \
        -DLLVM_EXTERNAL_PROJECTS="sycl;llvm-spirv;opencl;libdevice;xpti;xptifw" \
-       -DLLVM_ENABLE_PROJECTS="clang;compiler-rt;sycl;llvm-spirv;opencl;libdevice;xpti;xptifw;libclc;lld" \
+       -DLLVM_ENABLE_PROJECTS="clang;compiler-rt;sycl;llvm-spirv;opencl;libdevice;xpti;xptifw;libclc;lld;clang-tools-extra;openmp" \
        -DLLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR=${LLVM_SOURCE_DIR}/llvm-spirv     \
        -DLLVM_EXTERNAL_SYCL_SOURCE_DIR=${LLVM_SOURCE_DIR}/sycl                 \
        -DLLVM_EXTERNAL_LIBDEVICE_SOURCE_DIR=${LLVM_SOURCE_DIR}/libdevice       \
-       -DLLVM_EXTERNAL_OPENCL_SOURCE_DIR=${LLVM_SOURCE_DIR}/opencl             \
        -DLLVM_EXTERNAL_XPTI_SOURCE_DIR=${LLVM_SOURCE_DIR}/xpti                 \
        -DXPTI_SOURCE_DIR=${LLVM_SOURCE_DIR}/xpti                               \
        -DLLVM_EXTERNAL_XPTIFW_SOURCE_DIR=${LLVM_SOURCE_DIR}/xptifw             \
        -DLIBCLC_TARGETS_TO_BUILD="amdgcn--;amdgcn--amdhsa"                     \
-       -DLIBCLC_GENERATE_REMANGLED_VARIANTS=ON -DSYCL_BUILD_PI_HIP=ON          \
-       -DSYCL_BUILD_PI_HIP_PLATFORM=AMD -DLLVM_BUILD_TOOLS=ON                  \
-       -DSYCL_ENABLE_WERROR=OFF -DSYCL_ENABLE_XPTI_TRACING=ON                  \
-       -DLLVM_ENABLE_LLD=OFF -DLLVM_ENABLE_EH=ON -DLLVM_ENABLE_PIC=ON          \
-       -DLLVM_ENABLE_RTTI=ON -DOpenCL_INSTALL_KHRONOS_ICD_LOADER=TRUE          \
-       -DSYCL_CLANG_EXTRA_FLAGS="-Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx803" \
+       -DLIBCLC_GENERATE_REMANGLED_VARIANTS=ON                                 \
+       -DLLVM_BUILD_TOOLS=ON -DSYCL_ENABLE_WERROR=OFF                          \
+       -DSYCL_INCLUDE_TESTS=OFF -DLLVM_ENABLE_DOXYGEN=OFF                      \
+       -DLLVM_ENABLE_SPHINX=OFF -DBUILD_SHARED_LIBS=OFF                        \
+       -DSYCL_ENABLE_XPTI_TRACING=ON -DLLVM_ENABLE_LLD=OFF                     \
+       -DLLVM_ENABLE_PIC=ON -DLLVM_ENABLE_RTTI=ON -DXPTI_ENABLE_WERROR=OFF     \
+       -DOpenCL_INSTALL_KHRONOS_ICD_LOADER=TRUE                                \
+       -DSYCL_ENABLE_PLUGINS="opencl;level_zero;hip"                           \
        -S ${LLVM_SOURCE_DIR}/llvm/ -B ${LLVM_BINARY_DIR} &&                    \
+    export MAKEFLAGS=-j`nproc` &&                                              \
     cmake --build ${LLVM_BINARY_DIR} &&                                        \
     cmake --build ${LLVM_BINARY_DIR} --target sycl-toolchain &&                \
     cmake --install ${LLVM_BINARY_DIR} &&                                      \

--- a/ubuntu1804_rocm_oneapi/llvm-2022-06-python3.6.patch
+++ b/ubuntu1804_rocm_oneapi/llvm-2022-06-python3.6.patch
@@ -1,0 +1,37 @@
+diff --git a/sycl/plugins/level_zero/ze_api_generator.py b/sycl/plugins/level_zero/ze_api_generator.py
+index ca70341c93a4..b49060beb7bf 100644
+--- a/sycl/plugins/level_zero/ze_api_generator.py
++++ b/sycl/plugins/level_zero/ze_api_generator.py
+@@ -35,6 +35,6 @@ def extract_ze_apis(header):
+     api.close()
+ 
+ if __name__ == "__main__":
+-    with open(sys.argv[1], 'r') as f:
++    with open(sys.argv[1], 'r', encoding='utf-8') as f:
+         header = f.read()
+         extract_ze_apis(header)
+diff --git a/sycl/tools/sycl-trace/generate_pi_pretty_printers.py b/sycl/tools/sycl-trace/generate_pi_pretty_printers.py
+index 07b0c3a41c94..f290c73414c9 100644
+--- a/sycl/tools/sycl-trace/generate_pi_pretty_printers.py
++++ b/sycl/tools/sycl-trace/generate_pi_pretty_printers.py
+@@ -49,6 +49,6 @@ if __name__ == "__main__":
+     """
+     Usage: python generate_pi_pretty_printers.py path/to/pi.h
+     """
+-    with open(sys.argv[1], 'r') as f:
++    with open(sys.argv[1], 'r', encoding='utf-8') as f:
+         header = f.read()
+         generate_pi_pretty_printers(header)
+diff --git a/sycl/tools/sycl-trace/generate_ze_pretty_printers.py b/sycl/tools/sycl-trace/generate_ze_pretty_printers.py
+index 40d1b600b9c5..f4df492c6ea5 100644
+--- a/sycl/tools/sycl-trace/generate_ze_pretty_printers.py
++++ b/sycl/tools/sycl-trace/generate_ze_pretty_printers.py
+@@ -53,7 +53,7 @@ if __name__ == "__main__":
+     """
+     Usage: python generate_pi_pretty_printers.py path/to/ze_api.h
+     """
+-    with open(sys.argv[1], 'r') as f:
++    with open(sys.argv[1], 'r', encoding='utf-8') as f:
+         header = f.read()
+         generate_ze_pretty_printers(header)
+ 


### PR DESCRIPTION
Updated the Ubuntu 18.04 images to build [intel/llvm tag 2022-06](https://github.com/intel/llvm/releases/tag/2022-06).

Note that the Intel compiler is not "super supported" on Ubuntu 18.04 anymore. So I think this will be the last hurrah for these imaqes, I won't be updating them to any newer versions of the compiler. (Figuring out how I needed to patch them was a bit too much of a hassle this time around already.)

I'll have one more PR before we should make a `v31` tag, on top of which I'll have yet another PR. :stuck_out_tongue: