### PR TITLE
Introduce ubuntu2004_rocm, master branch (2022.11.03.)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -29,6 +29,7 @@ jobs:
           - ubuntu1804_rocm_oneapi
           - ubuntu2004
           - ubuntu2004_cuda
+          - ubuntu2004_rocm
           - ubuntu2004_oneapi
           - ubuntu2004_exatrkx
           - ubuntu2004_exatrkx_training

--- a/ubuntu2004_rocm/Dockerfile
+++ b/ubuntu2004_rocm/Dockerfile
@@ -1,0 +1,187 @@
+FROM rocm/dev-ubuntu-20.04:5.3
+
+LABEL description="Ubuntu 20.04 with Acts dependencies and ROCm"
+LABEL maintainer="Paul Gessinger <paul.gessinger@cern.ch"
+# increase whenever any of the RUN commands change
+LABEL version="1"
+
+# DEBIAN_FRONTEND ensures non-blocking operation (tzdata is a problem)
+ENV DEBIAN_FRONTEND noninteractive
+
+# install dependencies from the package manager.
+#
+# see also https://root.cern.ch/build-prerequisites
+RUN apt-get update -y \
+  && apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    freeglut3-dev \
+    libboost-dev \
+    libboost-filesystem-dev \
+    libboost-program-options-dev \
+    libboost-test-dev \
+    libexpat-dev \
+    libeigen3-dev \
+    libftgl-dev \
+    libgl2ps-dev \
+    libglew-dev \
+    libgsl-dev \
+    liblz4-dev \
+    liblzma-dev \
+    libpcre3-dev \
+    libtbb-dev \
+    libx11-dev \
+    libxext-dev \
+    libxft-dev \
+    libxpm-dev \
+    libxerces-c-dev \
+    libzstd-dev \
+    ninja-build \
+    python3 \
+    python3-dev \
+    python3-pip \
+    rsync \
+    zlib1g-dev \
+    ccache \
+  && apt-get clean -y
+
+# manual builds for hep-specific packages
+ENV GET curl --location --silent --create-dirs
+ENV UNPACK_TO_SRC tar -xz --strip-components=1 --directory src
+ENV PREFIX /usr/local
+
+# CMake 3.16.3 version in APT is too old
+# requires rsync; installation uses `rsync` instead of `install`
+RUN mkdir src \
+  && ${GET} https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-Linux-x86_64.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && rsync -ruv src/ ${PREFIX} \
+  && cd .. \
+  && rm -rf src
+
+# Geant4
+RUN mkdir src \
+  && ${GET} https://geant4-data.web.cern.ch/geant4-data/releases/geant4.10.06.p01.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DGEANT4_BUILD_CXXSTD=17 \
+    -DGEANT4_INSTALL_DATA=OFF \
+    -DGEANT4_USE_GDML=ON \
+    -DGEANT4_USE_SYSTEM_EXPAT=ON \
+    -DGEANT4_USE_SYSTEM_ZLIB=ON \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# HepMC3
+RUN mkdir src \
+  && ${GET} https://hepmc.web.cern.ch/hepmc/releases/HepMC3-3.2.1.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DHEPMC3_BUILD_STATIC_LIBS=OFF \
+    -DHEPMC3_ENABLE_PYTHON=OFF \
+    -DHEPMC3_ENABLE_ROOTIO=OFF \
+    -DHEPMC3_ENABLE_SEARCH=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# Pythia8
+# requires rsync; installation uses `rsync` instead of `install`
+RUN mkdir src \
+  && ${GET} https://pythia.org/download/pythia82/pythia8244.tgz \
+    | ${UNPACK_TO_SRC} \
+  && cd src \
+  && ./configure --enable-shared --prefix=${PREFIX} \
+  && make -j$(nproc) install \
+  && cd .. \
+  && rm -rf src
+
+# xxHash
+RUN mkdir src \
+  && ${GET} https://github.com/Cyan4973/xxHash/archive/v0.7.3.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src/cmake_unofficial -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# nlohmann's JSON
+RUN mkdir src \
+  && ${GET} https://github.com/nlohmann/json/archive/refs/tags/v3.10.2.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DJSON_BuildTests=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# ROOT
+RUN mkdir src \
+  && ${GET} https://root.cern/download/root_v6.24.06.source.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -Dfail-on-missing=ON \
+    -Dgminimal=ON \
+    -Dgdml=ON \
+    -Dopengl=ON \
+    -Dpyroot=ON \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# environment variables needed to find ROOT libraries
+ENV LD_LIBRARY_PATH /usr/local/lib
+ENV PYTHON_PATH /usr/local/lib
+
+# podio
+RUN mkdir src \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_PREFIX_PATH=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -USE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# EDM4hep
+RUN pip3 install jinja2 pyyaml \
+  && mkdir src \
+  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-02.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_PREFIX_PATH=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -DUSE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- install \
+  && rm -rf build src
+
+# DD4hep
+# requires Geant4 and ROOT and must come last
+RUN mkdir src \
+  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-21.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_PREFIX_PATH=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -DDD4HEP_BUILD_PACKAGES="DDG4" \
+    -DDD4HEP_IGNORE_GEANT4_TLS=ON \
+    -DDD4HEP_USE_GEANT4=ON \
+    -DDD4HEP_USE_XERCESC=ON \
+    -DDD4HEP_USE_EDM4HEP=ON \
+  && cmake --build build -- install \
+  && rm -rf build src


### PR DESCRIPTION
Introduced `ubuntu2004_rocm` as a copy of `ubuntu2004_cuda`. Simply based on a different base image. (At one point we'll need to find a way for these configurations to be shared between the images...)

While Intel still recommends using ROCm 4.2 with their compiler, on our development machine the latest Intel compiler tag works correctly with ROCm 5.3 as well. So let's go for this right away, the `ubuntu1804_rocm` image will stay usable with ROCm 4.2 for a bit longer anyway.

Once this and #73 are in, we should make a new tag. :wink: