### PR TITLE
Compile ROOT with RDataFrame

### DIFF
--- a/ubuntu2204/Dockerfile
+++ b/ubuntu2204/Dockerfile
@@ -115,6 +115,7 @@ RUN mkdir src \
     -Dgdml=ON \
     -Dopengl=ON \
     -Dpyroot=ON \
+    -Ddataframe=ON \
   && cmake --build build -- install \
   && rm -rf build src
 


### PR DESCRIPTION
Compile ROOT with DataFrame.

Needed for analysis scripts (ECal performance) of OpenDataDetector.

Added only to ubuntu2204.