### PR TITLE
Add ability for images to extend each other

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -11,92 +11,33 @@ on:
   schedule:
     - cron: '0 3 * * 1'
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    permissions:
-      packages: write
-    strategy:
-      matrix:
-        context:
-          - centos7-lcg100-gcc10
-          - centos7-lcg101-gcc11
-          - centos8-lcg100-gcc10
-          - centos8-lcg101-gcc11
-          - format10
-          - format14
-          - ubuntu2004
-          - ubuntu2004_cuda
-          - ubuntu2004_cuda_oneapi
-          - ubuntu2004_rocm
-          - ubuntu2004_rocm_oneapi
-          - ubuntu2004_oneapi
-          - ubuntu2004_exatrkx
-          - ubuntu2204
-          - ubuntu2204_clang
-          - ubuntu2204_cpp20
-          - centos7-base
-          - centos8-base
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check size of packages
-        run: |
-          df -h
-          sudo apt-get update
-          echo "Listing 25 largest packages"
-          dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 25
-          echo "Removing large packages"
-          sudo apt-get remove -y '^dotnet-.*'
-          sudo apt-get remove -y '^llvm-.*'
-          sudo apt-get remove -y '^libllvm-.*'
-          sudo apt-get remove -y azure-cli 
-          sudo apt-get remove -y google-cloud-cli
-          sudo apt-get remove -y google-chrome-stable
-          sudo apt-get remove -y firefox
-          sudo apt-get remove -y powershell
-          sudo apt-get remove -y mono-devel
-          sudo apt-get remove -y '^temurin.*'
-          sudo apt-get autoremove -y
-          sudo apt-get clean
-          rm -rf /usr/share/dotnet/
-          df -h
-          
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          # list of Docker images to use as base name for tags
-          images: |
-            ghcr.io/${{ github.repository_owner  }}/${{ matrix.context }}
-          # generate Docker tags based on the following events/attributes
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=sha        
-
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: ${{ matrix.context }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner  }}/${{ matrix.context }}:buildcache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner  }}/${{ matrix.context }}:buildcache,mode=max
+  tier0:
+    name: Build tier-0 images
+    uses: ./.github/actions/reusable-build-images.yml
+    with:
+      images: >
+        [
+          "centos7-lcg100-gcc10"
+          "centos7-lcg101-gcc11"
+          "centos8-lcg100-gcc10"
+          "centos8-lcg101-gcc11"
+          "format10"
+          "format14"
+          "ubuntu2004"
+          "ubuntu2004_cuda"
+          "ubuntu2004_cuda_oneapi"
+          "ubuntu2004_rocm"
+          "ubuntu2004_rocm_oneapi"
+          "ubuntu2004_oneapi"
+          "ubuntu2004_exatrkx"
+          "ubuntu2204"
+          "ubuntu2204_clang"
+          "ubuntu2204_cpp20"
+          "centos7-base"
+          "centos8-base"
+        ]

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   tier0:
     name: Build tier-0 images
-    uses: ./.github/actions/reusable-build-images.yml
+    uses: ./.github/workflows/reusable-build-images.yml
     with:
       images: >
         [

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -41,3 +41,11 @@ jobs:
           "centos7-base",
           "centos8-base",
         ]
+  tier1:
+    name: Build tier-1 images
+    uses: ./.github/workflows/reusable-build-images.yml
+    with:
+      images: >
+        [
+          "ubuntu2204_extend_test",
+        ]

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -22,22 +22,22 @@ jobs:
     with:
       images: >
         [
-          "centos7-lcg100-gcc10"
-          "centos7-lcg101-gcc11"
-          "centos8-lcg100-gcc10"
-          "centos8-lcg101-gcc11"
-          "format10"
-          "format14"
-          "ubuntu2004"
-          "ubuntu2004_cuda"
-          "ubuntu2004_cuda_oneapi"
-          "ubuntu2004_rocm"
-          "ubuntu2004_rocm_oneapi"
-          "ubuntu2004_oneapi"
-          "ubuntu2004_exatrkx"
-          "ubuntu2204"
-          "ubuntu2204_clang"
-          "ubuntu2204_cpp20"
-          "centos7-base"
-          "centos8-base"
+          "centos7-lcg100-gcc10",
+          "centos7-lcg101-gcc11",
+          "centos8-lcg100-gcc10",
+          "centos8-lcg101-gcc11",
+          "format10",
+          "format14",
+          "ubuntu2004",
+          "ubuntu2004_cuda",
+          "ubuntu2004_cuda_oneapi",
+          "ubuntu2004_rocm",
+          "ubuntu2004_rocm_oneapi",
+          "ubuntu2004_oneapi",
+          "ubuntu2004_exatrkx",
+          "ubuntu2204",
+          "ubuntu2204_clang",
+          "ubuntu2204_cpp20",
+          "centos7-base",
+          "centos8-base",
         ]

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -44,6 +44,7 @@ jobs:
   tier1:
     name: Build tier-1 images
     uses: ./.github/workflows/reusable-build-images.yml
+    needs: tier0
     with:
       images: >
         [

--- a/.github/workflows/reusable-build-images.yml
+++ b/.github/workflows/reusable-build-images.yml
@@ -1,0 +1,81 @@
+name: Reuable build images
+
+on:
+  workflow_call:
+    inputs:
+      images:
+        description: "Images to build"
+        type: string
+        required: true
+
+permissions:
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        context: ${{ fromJson(inputs.images) }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check size of packages
+        run: |
+          df -h
+          sudo apt-get update
+          echo "Listing 25 largest packages"
+          dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 25
+          echo "Removing large packages"
+          sudo apt-get remove -y '^dotnet-.*'
+          sudo apt-get remove -y '^llvm-.*'
+          sudo apt-get remove -y '^libllvm-.*'
+          sudo apt-get remove -y azure-cli 
+          sudo apt-get remove -y google-cloud-cli
+          sudo apt-get remove -y google-chrome-stable
+          sudo apt-get remove -y firefox
+          sudo apt-get remove -y powershell
+          sudo apt-get remove -y mono-devel
+          sudo apt-get remove -y '^temurin.*'
+          sudo apt-get autoremove -y
+          sudo apt-get clean
+          rm -rf /usr/share/dotnet/
+          df -h
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/${{ github.repository_owner  }}/${{ matrix.context }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner  }}/${{ matrix.context }}:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner  }}/${{ matrix.context }}:buildcache,mode=max

--- a/ubuntu2204_extend_test/Dockerfile
+++ b/ubuntu2204_extend_test/Dockerfile
@@ -1,0 +1,15 @@
+FROM ghcr.io/acts-project/ubuntu2204
+
+LABEL description="Ubuntu 22.04 with Acts dependencies"
+LABEL maintainer="Paul Gessinger <paul.gessinger@cern.ch>"
+# increase whenever any of the RUN commands change
+LABEL version="1"
+
+# DEBIAN_FRONTEND ensures non-blocking operation (tzdata is a problem)
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update -y \
+  && apt-get upgrade -y \
+  && apt-get install -y \
+  supertuxkart \
+  && apt-get clean -y


### PR DESCRIPTION
The current state of the machines repository is that many of the images share code between them and that they each compile all their dependencies, etc. separately. This has a few issues in my mind:

1. It consumes a large amount of CPU cycles recompiling the same dependencies over and over.
2. It wastes a bunch of space storing very similar layers in multiple places.
3. It duplicates a lot of `Dockerfile` code between images.
4. It increases the barrier of entry to adding new images, because each image is both quite complex and takes a long time to build.

It also has a very clear upside that it decreases wall clock time by just building a ton of images in parallel.

I'd like to propose this work-in-progress strategy for allowing images to extend other images. This works by making the image building process a reusable workflow and calling that workflow in multiple tiers. I imagine that all tier 0 images can be built as-is, all tier 1 images can be built if all the tier 0 images are built, and so forth. Automatic dependency determination seems impossible to do while preserving the parallel nature of GitHub actions.

I have included an example of how we can then extend lower-tier images.

I imagine this would bring the following benefits:

1. It would decrease the total CPU time spent building images.
2. It would decrease the amount of code duplication between images.
3. It would decrease the total disk usage of images.
4. It would allow us to create more fine-grained images, such as images for traccc which have ACTS pre-compiled such that we can save CPU time compiling all of ACTS every time we compile traccc.

Of course, it would also increase the wall clock time of the machines build, but I imagine it would not be too significant.

Very interested in comments on this idea. Certainly not a final implementation just yet. :smile: 