### PR TITLE
Ubuntu 20.04 GPU Image Rewrite, master branch (2024.05.19.)

### DIFF
--- a/ubuntu2004_cuda/Dockerfile
+++ b/ubuntu2004_cuda/Dockerfile
@@ -1,198 +1,33 @@
-FROM nvidia/cuda:11.6.2-devel-ubuntu20.04
+# Docker machinery, part of the ACTS project
+#
+# (c) 2021-2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
 
+# Start from the (at the time of writing) latest Acts Ubuntu 20.04 image.
+FROM ghcr.io/acts-project/ubuntu2004:v43
+
+# Some description for the image.
 LABEL description="Ubuntu 20.04 with Acts dependencies and CUDA"
 LABEL maintainer="Paul Gessinger <paul.gessinger@cern.ch"
-# increase whenever any of the RUN commands change
-LABEL version="1"
 
-# DEBIAN_FRONTEND ensures non-blocking operation (tzdata is a problem)
-ENV DEBIAN_FRONTEND noninteractive
+# Add the Ubuntu 20.04 CUDA repository.
+RUN curl -SL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.1-1_all.deb \
+       -o cuda-keyring.deb && \
+    dpkg -i cuda-keyring.deb && \
+    rm cuda-keyring.deb
 
-# install dependencies from the package manager.
-#
-# see also https://root.cern.ch/build-prerequisites
-RUN apt-get update -y \
-  && apt-get install -y \
-    build-essential \
-    curl \
-    git \
-    freeglut3-dev \
-    libboost-dev \
-    libboost-filesystem-dev \
-    libboost-program-options-dev \
-    libboost-test-dev \
-    libexpat-dev \
-    libeigen3-dev \
-    libftgl-dev \
-    libgl2ps-dev \
-    libglew-dev \
-    libgsl-dev \
-    liblz4-dev \
-    liblzma-dev \
-    libpcre3-dev \
-    libtbb-dev \
-    libx11-dev \
-    libxext-dev \
-    libxft-dev \
-    libxpm-dev \
-    libxerces-c-dev \
-    libzstd-dev \
-    ninja-build \
-    python3 \
-    python3-dev \
-    python3-pip \
-    rsync \
-    zlib1g-dev \
-    ccache \
-  && apt-get clean -y
+# Install CUDA.
+ARG CUDA_VERSION=12-4
+RUN apt-get update && \
+    apt-get install -y cuda-compat-${CUDA_VERSION} cuda-cudart-${CUDA_VERSION} \
+                       cuda-libraries-${CUDA_VERSION}                          \
+                       cuda-command-line-tools-${CUDA_VERSION}                 \
+                       cuda-minimal-build-${CUDA_VERSION} &&                   \
+    apt-get clean -y
 
-# manual builds for hep-specific packages
-ENV GET curl --location --silent --create-dirs
-ENV UNPACK_TO_SRC tar -xz --strip-components=1 --directory src
-ENV PREFIX /usr/local
-
-# CMake 3.16.3 version in APT is too old
-# requires rsync; installation uses `rsync` instead of `install`
-RUN mkdir src \
-  && ${GET} https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-Linux-x86_64.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && rsync -ruv src/ ${PREFIX} \
-  && cd .. \
-  && rm -rf src
-
-# Geant4
-RUN mkdir src \
-  && ${GET} https://geant4-data.web.cern.ch/geant4-data/releases/geant4.10.06.p01.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DGEANT4_BUILD_CXXSTD=17 \
-    -DGEANT4_INSTALL_DATA=OFF \
-    -DGEANT4_USE_GDML=ON \
-    -DGEANT4_USE_SYSTEM_EXPAT=ON \
-    -DGEANT4_USE_SYSTEM_ZLIB=ON \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# HepMC3
-RUN mkdir src \
-  && ${GET} https://hepmc.web.cern.ch/hepmc/releases/HepMC3-3.2.1.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DHEPMC3_BUILD_STATIC_LIBS=OFF \
-    -DHEPMC3_ENABLE_PYTHON=OFF \
-    -DHEPMC3_ENABLE_ROOTIO=OFF \
-    -DHEPMC3_ENABLE_SEARCH=OFF \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# Pythia8
-# requires rsync; installation uses `rsync` instead of `install`
-RUN mkdir src \
-  && ${GET} https://pythia.org/download/pythia82/pythia8244.tgz \
-    | ${UNPACK_TO_SRC} \
-  && cd src \
-  && ./configure --enable-shared --prefix=${PREFIX} \
-  && make -j$(nproc) install \
-  && cd .. \
-  && rm -rf src
-
-# xxHash
-RUN mkdir src \
-  && ${GET} https://github.com/Cyan4973/xxHash/archive/v0.7.3.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src/cmake_unofficial -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# nlohmann's JSON
-RUN mkdir src \
-  && ${GET} https://github.com/nlohmann/json/archive/refs/tags/v3.10.2.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DJSON_BuildTests=OFF \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# ROOT
-RUN mkdir src \
-  && ${GET} https://root.cern/download/root_v6.24.06.source.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_CXX_STANDARD=17 \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -Dfail-on-missing=ON \
-    -Dgminimal=ON \
-    -Dgdml=ON \
-    -Dopengl=ON \
-    -Dpyroot=ON \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# environment variables needed to find ROOT libraries
-ENV LD_LIBRARY_PATH /usr/local/lib
-ENV PYTHON_PATH /usr/local/lib
-
-# podio
-RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DCMAKE_PREFIX_PATH=${PREFIX} \
-    -DBUILD_TESTING=OFF \
-    -USE_EXTERNAL_CATCH2=OFF \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# EDM4hep
-RUN pip3 install jinja2 pyyaml \
-  && mkdir src \
-  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-02.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DCMAKE_PREFIX_PATH=${PREFIX} \
-    -DBUILD_TESTING=OFF \
-    -DUSE_EXTERNAL_CATCH2=OFF \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# DD4hep
-# requires Geant4 and ROOT and must come last
-RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-21.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_CXX_STANDARD=17 \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DCMAKE_PREFIX_PATH=${PREFIX} \
-    -DBUILD_TESTING=OFF \
-    -DDD4HEP_BUILD_PACKAGES="DDG4" \
-    -DDD4HEP_IGNORE_GEANT4_TLS=ON \
-    -DDD4HEP_USE_GEANT4=ON \
-    -DDD4HEP_USE_XERCESC=ON \
-    -DDD4HEP_USE_EDM4HEP=ON \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# Onnx (download of tar.gz does not work out of the box, since the build.sh script requires a git repository)
-RUN git clone https://github.com/microsoft/onnxruntime src \
-  && (cd src && git checkout v1.13.1) \
-  && ./src/build.sh \
-    --config MinSizeRel \
-    --build_shared_lib \
-    --build_dir build \
-    --skip_tests \
-  && cmake --build build/MinSizeRel -- install \
-  && rm -rf build src
+# Set up the CUDA environment.
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+ENV PATH=/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:${LD_LIBRARY_PATH}

--- a/ubuntu2004_cuda_oneapi/Dockerfile
+++ b/ubuntu2004_cuda_oneapi/Dockerfile
@@ -1,53 +1,57 @@
+# Docker machinery, part of the ACTS project
 #
-# Image building the Intel LLVM compiler from scratch, with Intel and NVidia
-# backend support.
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
+# Mozilla Public License Version 2.0
 
-# Base the image on the repository's ubuntu2004_cuda configuration.
-FROM ghcr.io/acts-project/ubuntu2004_cuda:v36
+# Start from the (at the time of writing) latest Acts Ubuntu 20.04 image.
+FROM ghcr.io/acts-project/ubuntu2004:v43
 
-# Build the Intel DPC++ compiler from source.
-ARG LLVM_VERSION=2022-12
-ARG LLVM_SOURCE_DIR=/root/llvm
-ARG LLVM_BINARY_DIR=/root/build
-RUN git clone https://github.com/intel/llvm.git ${LLVM_SOURCE_DIR} &&          \
-    cd ${LLVM_SOURCE_DIR}/ && git checkout ${LLVM_VERSION} &&                  \
-    cmake -DCMAKE_BUILD_TYPE=Release                                           \
-       -DCMAKE_INSTALL_PREFIX=${PREFIX}                                        \
-       -DLLVM_ENABLE_ASSERTIONS=ON -DCMAKE_INSTALL_LIBDIR=lib                  \
-       -DLLVM_TARGETS_TO_BUILD="X86;NVPTX"                                     \
-       -DLLVM_EXTERNAL_PROJECTS="sycl;sycl-fusion;llvm-spirv;opencl;libdevice;xpti;xptifw" \
-       -DLLVM_ENABLE_PROJECTS="clang;compiler-rt;sycl;sycl-fusion;llvm-spirv;opencl;libdevice;xpti;xptifw;libclc;lld;clang-tools-extra;openmp" \
-       -DLLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR=${LLVM_SOURCE_DIR}/llvm-spirv     \
-       -DLLVM_EXTERNAL_SYCL_SOURCE_DIR=${LLVM_SOURCE_DIR}/sycl                 \
-       -DLLVM_EXTERNAL_SYCL_FUSION_SOURCE_DIR=${LLVM_SOURCE_DIR}/sycl-fusion   \
-       -DLLVM_EXTERNAL_LIBDEVICE_SOURCE_DIR=${LLVM_SOURCE_DIR}/libdevice       \
-       -DLLVM_EXTERNAL_XPTI_SOURCE_DIR=${LLVM_SOURCE_DIR}/xpti                 \
-       -DXPTI_SOURCE_DIR=${LLVM_SOURCE_DIR}/xpti                               \
-       -DLLVM_EXTERNAL_XPTIFW_SOURCE_DIR=${LLVM_SOURCE_DIR}/xptifw             \
-       -DLIBCLC_TARGETS_TO_BUILD="nvptx64--;nvptx64--nvidiacl"                 \
-       -DLIBCLC_GENERATE_REMANGLED_VARIANTS=ON                                 \
-       -DLLVM_BUILD_TOOLS=ON -DSYCL_ENABLE_WERROR=OFF                          \
-       -DSYCL_INCLUDE_TESTS=OFF -DLLVM_ENABLE_DOXYGEN=OFF                      \
-       -DLLVM_ENABLE_SPHINX=OFF -DBUILD_SHARED_LIBS=OFF                        \
-       -DSYCL_ENABLE_XPTI_TRACING=ON -DLLVM_ENABLE_LLD=OFF                     \
-       -DLLVM_ENABLE_PIC=ON -DLLVM_ENABLE_RTTI=ON -DXPTI_ENABLE_WERROR=OFF     \
-       -DOpenCL_INSTALL_KHRONOS_ICD_LOADER=TRUE                                \
-       -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda                                 \
-       -DCMAKE_PREFIX_PATH=/usr/local/cuda/compat                              \
-       -DSYCL_ENABLE_PLUGINS="opencl;level_zero;cuda"                          \
-       -DSYCL_ENABLE_KERNEL_FUSION=ON                                          \
-       -S ${LLVM_SOURCE_DIR}/llvm/ -B ${LLVM_BINARY_DIR} &&                    \
-    export MAKEFLAGS=-j`nproc` &&                                              \
-    cmake --build ${LLVM_BINARY_DIR} --target intrinsics_gen &&                \
-    cmake --build ${LLVM_BINARY_DIR} &&                                        \
-    cmake --build ${LLVM_BINARY_DIR} --target sycl-toolchain &&                \
-    cmake --install ${LLVM_BINARY_DIR} &&                                      \
-    rm -rf ${LLVM_SOURCE_DIR} ${LLVM_BINARY_DIR}
+# Some description for the image.
+LABEL description="Ubuntu 20.04 with Acts dependencies and CUDA + oneAPI"
+LABEL maintainer="Paul Gessinger <paul.gessinger@cern.ch"
 
-# Set up the correct runtime environment for using the compiler(s).
-ENV CC="${PREFIX}/bin/clang"
-ENV CXX="${PREFIX}/bin/clang++"
-ENV SYCLCXX="${CXX} -fsycl -fsycl-targets=nvptx64-nvidia-cuda"
-ENV CUDAHOSTCXX="${CXX}"
-ENV CUDAFLAGS="-std=c++17 -allow-unsupported-compiler"
+# Add the Ubuntu 20.04 CUDA repository.
+RUN curl -SL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.1-1_all.deb \
+       -o cuda-keyring.deb && \
+    dpkg -i cuda-keyring.deb && \
+    rm cuda-keyring.deb
+
+# Install CUDA.
+ARG CUDA_VERSION=12-4
+RUN apt-get update && \
+    apt-get install -y cuda-compat-${CUDA_VERSION} cuda-cudart-${CUDA_VERSION} \
+                       cuda-libraries-${CUDA_VERSION}                          \
+                       cuda-command-line-tools-${CUDA_VERSION}                 \
+                       cuda-minimal-build-${CUDA_VERSION} &&                   \
+    apt-get clean -y
+
+# Set up the CUDA environment.
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+ENV PATH=/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
+ENV CUDAHOSTCXX="clang++"
+ENV CUDAFLAGS="-allow-unsupported-compiler"
+
+# Set up the Intel package signing key.
+RUN mkdir --parents --mode=0755 /etc/apt/keyrings && \
+    curl -SL https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \
+    gpg --dearmor > /usr/share/keyrings/oneapi-archive-keyring.gpg
+
+# Set up the oneAPI repository.
+COPY oneapi.list /etc/apt/sources.list.d/
+
+# Install oneAPI.
+ARG ONEAPI_VERSION=2024.1
+RUN apt-get update && \
+    apt-get install -y intel-oneapi-compiler-dpcpp-cpp-${ONEAPI_VERSION} && \
+    apt-get clean -y
+
+# Set up the oneAPI environment. Note that one *MUST* source the
+# /opt/intel/oneapi/setvars.sh script to make the following work. Which has to
+# be done in the respective CI scripts.
+ENV CC="clang"
+ENV CXX="clang++"
+ENV SYCLCXX="clang++ -fsycl"
+ENV SYCLFLAGS="-fsycl-targets=spir64,spir64_x86_64,nvidia_gpu_sm_75 -Wno-unknown-cuda-version -Xclang -opaque-pointers"

--- a/ubuntu2004_cuda_oneapi/oneapi.list
+++ b/ubuntu2004_cuda_oneapi/oneapi.list
@@ -1,0 +1,1 @@
+deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main

--- a/ubuntu2004_oneapi/Dockerfile
+++ b/ubuntu2004_oneapi/Dockerfile
@@ -1,208 +1,34 @@
-FROM ubuntu:20.04
+# Docker machinery, part of the ACTS project
+#
+# (c) 2021-2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
 
-LABEL description="Ubuntu 20.04 with Acts dependencies"
-LABEL maintainer="Paul Gessinger <paul.gessinger@cern.ch>"
-# increase whenever any of the RUN commands change
-LABEL version="1"
+# Start from the (at the time of writing) latest Acts Ubuntu 20.04 image.
+FROM ghcr.io/acts-project/ubuntu2004:v43
 
-# DEBIAN_FRONTEND ensures non-blocking operation (tzdata is a problem)
-ENV DEBIAN_FRONTEND noninteractive
+# Some description for the image.
+LABEL description="Ubuntu 20.04 with Acts dependencies and oneAPI"
+LABEL maintainer="Paul Gessinger <paul.gessinger@cern.ch"
 
-# Get the packages necessary to set up the Intel repository.
-RUN apt-get update -y \
-  && apt-get install -y gnupg2 curl \
-  && apt-get clean -y
+# Set up the Intel package signing key.
+RUN mkdir --parents --mode=0755 /etc/apt/keyrings && \
+    curl -SL https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \
+    gpg --dearmor > /usr/share/keyrings/oneapi-archive-keyring.gpg
 
-# Set up the Intel package repository.
-RUN curl https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | apt-key add - \
-  && echo "deb https://apt.repos.intel.com/oneapi all main" > /etc/apt/sources.list.d/oneAPI.list
+# Set up the oneAPI repository.
+COPY oneapi.list /etc/apt/sources.list.d/
 
-# Install the oneAPI compiler.
-RUN apt-get update -y \
-  && apt-get install -y \
-    intel-oneapi-compiler-dpcpp-cpp-2022.0.2 \
-  && apt-get clean -y
+# Install oneAPI.
+ARG ONEAPI_VERSION=2024.1
+RUN apt-get update && \
+    apt-get install -y intel-oneapi-compiler-dpcpp-cpp-${ONEAPI_VERSION} && \
+    apt-get clean -y
 
-# Set up the environment variables compelling CMake to use the Intel compilers.
-ENV CC icx
-ENV CXX icpx
-ENV SYCLCXX dpcpp
-
-# Install all packages needed by the Acts projects, and the other externals
-# built by hand.
-RUN apt-get update -y \
-  && apt-get install -y \
-    libstdc++-9-dev \
-    binutils \
-    make \
-    git \
-    freeglut3-dev \
-    libboost-dev \
-    libboost-filesystem-dev \
-    libboost-program-options-dev \
-    libboost-test-dev \
-    libeigen3-dev \
-    libexpat-dev \
-    libftgl-dev \
-    libgl2ps-dev \
-    libglew-dev \
-    libgsl-dev \
-    liblz4-dev \
-    liblzma-dev \
-    libpcre3-dev \
-    libtbb-dev \
-    libx11-dev \
-    libxext-dev \
-    libxft-dev \
-    libxpm-dev \
-    libxerces-c-dev \
-    libxxhash-dev \
-    libzstd-dev \
-    ninja-build \
-    python3 \
-    python3-dev \
-    python3-pip \
-    rsync \
-    zlib1g-dev \
-    ccache \
-  && apt-get remove --purge -y gcc-9 \
-  && apt-get autoremove -y \
-  && apt-get clean -y
-
-# manual builds for hep-specific packages
-ENV GET curl --location --silent --create-dirs
-ENV UNPACK_TO_SRC tar -xz --strip-components=1 --directory src
-ENV PREFIX /usr/local
-
-# CMake 3.16.3 version in APT is too old
-# requires rsync; installation uses `rsync` instead of `install`
-RUN mkdir src \
-  && ${GET} https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-Linux-x86_64.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && rsync -ruv src/ ${PREFIX} \
-  && cd .. \
-  && rm -rf src
-
-# Geant4
-RUN mkdir src \
-  && ${GET} https://geant4-data.web.cern.ch/releases/geant4.10.06.p01.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && . /opt/intel/oneapi/setvars.sh \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DGEANT4_BUILD_CXXSTD=17 \
-    -DGEANT4_INSTALL_DATA=OFF \
-    -DGEANT4_USE_GDML=ON \
-    -DGEANT4_USE_SYSTEM_EXPAT=ON \
-    -DGEANT4_USE_SYSTEM_ZLIB=ON \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# HepMC3
-RUN mkdir src \
-  && ${GET} https://hepmc.web.cern.ch/hepmc/releases/HepMC3-3.2.1.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && . /opt/intel/oneapi/setvars.sh \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DHEPMC3_BUILD_STATIC_LIBS=OFF \
-    -DHEPMC3_ENABLE_PYTHON=OFF \
-    -DHEPMC3_ENABLE_ROOTIO=OFF \
-    -DHEPMC3_ENABLE_SEARCH=OFF \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# Pythia8
-# requires rsync; installation uses `rsync` instead of `install`
-RUN mkdir src \
-  && ${GET} https://pythia.org/download/pythia82/pythia8244.tgz\
-    | ${UNPACK_TO_SRC} \
-  && cd src \
-  && . /opt/intel/oneapi/setvars.sh \
-  && ./configure --enable-shared --prefix=${PREFIX} \
-  && make -j$(nproc) install \
-  && cd .. \
-  && rm -rf src
-
-# nlohmann's JSON
-RUN mkdir src \
-  && ${GET} https://github.com/nlohmann/json/archive/refs/tags/v3.10.2.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && . /opt/intel/oneapi/setvars.sh \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DJSON_BuildTests=OFF \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# ROOT
-RUN mkdir src \
-  && ${GET} https://root.cern/download/root_v6.24.06.source.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && . /opt/intel/oneapi/setvars.sh \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_CXX_STANDARD=17 \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -Dfail-on-missing=ON \
-    -Dgminimal=ON \
-    -Dgdml=ON \
-    -Dopengl=ON \
-    -Dpyroot=ON \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# environment variables needed for DD4hep to find ROOT libraries
-ENV LD_LIBRARY_PATH /usr/local/lib
-ENV PYTHON_PATH /usr/local/lib
-
-# podio
-RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && . /opt/intel/oneapi/setvars.sh \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DCMAKE_PREFIX_PATH=${PREFIX} \
-    -DBUILD_TESTING=OFF \
-    -USE_EXTERNAL_CATCH2=OFF \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# EDM4hep
-RUN pip3 install jinja2 pyyaml \
-  && mkdir src \
-  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-02.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && . /opt/intel/oneapi/setvars.sh \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DCMAKE_PREFIX_PATH=${PREFIX} \
-    -DBUILD_TESTING=OFF \
-    -DUSE_EXTERNAL_CATCH2=OFF \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# DD4hep
-# requires Geant4 and ROOT and must come last
-RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-21.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && . /opt/intel/oneapi/setvars.sh \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_CXX_STANDARD=17 \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DCMAKE_PREFIX_PATH=${PREFIX} \
-    -DBUILD_TESTING=OFF \
-    -DDD4HEP_BUILD_PACKAGES="DDG4 DDDetectors DDRec" \
-    -DDD4HEP_IGNORE_GEANT4_TLS=ON \
-    -DDD4HEP_USE_GEANT4=ON \
-    -DDD4HEP_USE_XERCESC=ON \
-    -DDD4HEP_USE_EDM4HEP=ON \
-  && cmake --build build -- install \
-  && rm -rf build src
+# Set up the environment. Note that one *MUST* source the
+# /opt/intel/oneapi/setvars.sh script to make the following work. Which has to
+# be done in the respective CI scripts.
+ENV CC="clang"
+ENV CXX="clang++"
+ENV SYCLCXX="clang++ -fsycl"
+ENV SYCLFLAGS="-fsycl-targets=spir64,spir64_x86_64"

--- a/ubuntu2004_oneapi/oneapi.list
+++ b/ubuntu2004_oneapi/oneapi.list
@@ -1,0 +1,1 @@
+deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main

--- a/ubuntu2004_rocm/Dockerfile
+++ b/ubuntu2004_rocm/Dockerfile
@@ -1,198 +1,28 @@
-FROM rocm/dev-ubuntu-20.04:5.3
-
-LABEL description="Ubuntu 20.04 with Acts dependencies and ROCm"
-LABEL maintainer="Paul Gessinger <paul.gessinger@cern.ch"
-# increase whenever any of the RUN commands change
-LABEL version="1"
-
-# DEBIAN_FRONTEND ensures non-blocking operation (tzdata is a problem)
-ENV DEBIAN_FRONTEND noninteractive
-
-# install dependencies from the package manager.
+# Docker machinery, part of the ACTS project
 #
-# see also https://root.cern.ch/build-prerequisites
-RUN apt-get update -y \
-  && apt-get install -y \
-    build-essential \
-    curl \
-    git \
-    freeglut3-dev \
-    libboost-dev \
-    libboost-filesystem-dev \
-    libboost-program-options-dev \
-    libboost-test-dev \
-    libexpat-dev \
-    libeigen3-dev \
-    libftgl-dev \
-    libgl2ps-dev \
-    libglew-dev \
-    libgsl-dev \
-    liblz4-dev \
-    liblzma-dev \
-    libpcre3-dev \
-    libtbb-dev \
-    libx11-dev \
-    libxext-dev \
-    libxft-dev \
-    libxpm-dev \
-    libxerces-c-dev \
-    libzstd-dev \
-    ninja-build \
-    python3 \
-    python3-dev \
-    python3-pip \
-    rsync \
-    zlib1g-dev \
-    ccache \
-  && apt-get clean -y
+# (c) 2021-2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
 
-# manual builds for hep-specific packages
-ENV GET curl --location --silent --create-dirs
-ENV UNPACK_TO_SRC tar -xz --strip-components=1 --directory src
-ENV PREFIX /usr/local
+# Start from the (at the time of writing) latest Acts Ubuntu 20.04 image.
+FROM ghcr.io/acts-project/ubuntu2004:v43
 
-# CMake 3.16.3 version in APT is too old
-# requires rsync; installation uses `rsync` instead of `install`
-RUN mkdir src \
-  && ${GET} https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-Linux-x86_64.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && rsync -ruv src/ ${PREFIX} \
-  && cd .. \
-  && rm -rf src
+# Some description for the image.
+LABEL description="Ubuntu 20.04 with Acts dependencies and ROCm/HIP"
+LABEL maintainer="Paul Gessinger <paul.gessinger@cern.ch"
 
-# Geant4
-RUN mkdir src \
-  && ${GET} https://geant4-data.web.cern.ch/geant4-data/releases/geant4.10.06.p01.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DGEANT4_BUILD_CXXSTD=17 \
-    -DGEANT4_INSTALL_DATA=OFF \
-    -DGEANT4_USE_GDML=ON \
-    -DGEANT4_USE_SYSTEM_EXPAT=ON \
-    -DGEANT4_USE_SYSTEM_ZLIB=ON \
-  && cmake --build build -- install \
-  && rm -rf build src
+# Set up the ROCm package signing key.
+RUN mkdir --parents --mode=0755 /etc/apt/keyrings && \
+    curl -SL https://repo.radeon.com/rocm/rocm.gpg.key | \
+    gpg --dearmor > /etc/apt/keyrings/rocm.gpg
 
-# HepMC3
-RUN mkdir src \
-  && ${GET} https://hepmc.web.cern.ch/hepmc/releases/HepMC3-3.2.1.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DHEPMC3_BUILD_STATIC_LIBS=OFF \
-    -DHEPMC3_ENABLE_PYTHON=OFF \
-    -DHEPMC3_ENABLE_ROOTIO=OFF \
-    -DHEPMC3_ENABLE_SEARCH=OFF \
-  && cmake --build build -- install \
-  && rm -rf build src
+# Set up the ROCm repository.
+COPY rocm.list /etc/apt/sources.list.d/
+COPY rocm-pin-600 /etc/apt/preferences.d/
 
-# Pythia8
-# requires rsync; installation uses `rsync` instead of `install`
-RUN mkdir src \
-  && ${GET} https://pythia.org/download/pythia82/pythia8244.tgz \
-    | ${UNPACK_TO_SRC} \
-  && cd src \
-  && ./configure --enable-shared --prefix=${PREFIX} \
-  && make -j$(nproc) install \
-  && cd .. \
-  && rm -rf src
-
-# xxHash
-RUN mkdir src \
-  && ${GET} https://github.com/Cyan4973/xxHash/archive/v0.7.3.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src/cmake_unofficial -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# nlohmann's JSON
-RUN mkdir src \
-  && ${GET} https://github.com/nlohmann/json/archive/refs/tags/v3.10.2.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DJSON_BuildTests=OFF \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# ROOT
-RUN mkdir src \
-  && ${GET} https://root.cern/download/root_v6.24.06.source.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_CXX_STANDARD=17 \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -Dfail-on-missing=ON \
-    -Dgminimal=ON \
-    -Dgdml=ON \
-    -Dopengl=ON \
-    -Dpyroot=ON \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# environment variables needed to find ROOT libraries
-ENV LD_LIBRARY_PATH /usr/local/lib
-ENV PYTHON_PATH /usr/local/lib
-
-# podio
-RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v00-14-01.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DCMAKE_PREFIX_PATH=${PREFIX} \
-    -DBUILD_TESTING=OFF \
-    -USE_EXTERNAL_CATCH2=OFF \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# EDM4hep
-RUN pip3 install jinja2 pyyaml \
-  && mkdir src \
-  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-04-02.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DCMAKE_PREFIX_PATH=${PREFIX} \
-    -DBUILD_TESTING=OFF \
-    -DUSE_EXTERNAL_CATCH2=OFF \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# DD4hep
-# requires Geant4 and ROOT and must come last
-RUN mkdir src \
-  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-21.tar.gz \
-    | ${UNPACK_TO_SRC} \
-  && cmake -B build -S src -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_CXX_STANDARD=17 \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DCMAKE_PREFIX_PATH=${PREFIX} \
-    -DBUILD_TESTING=OFF \
-    -DDD4HEP_BUILD_PACKAGES="DDG4" \
-    -DDD4HEP_IGNORE_GEANT4_TLS=ON \
-    -DDD4HEP_USE_GEANT4=ON \
-    -DDD4HEP_USE_XERCESC=ON \
-    -DDD4HEP_USE_EDM4HEP=ON \
-  && cmake --build build -- install \
-  && rm -rf build src
-
-# Onnx (download of tar.gz does not work out of the box, since the build.sh script requires a git repository)
-RUN git clone https://github.com/microsoft/onnxruntime src \
-  && (cd src && git checkout v1.13.1) \
-  && ./src/build.sh \
-    --config MinSizeRel \
-    --build_shared_lib \
-    --build_dir build \
-    --skip_tests \
-  && cmake --build build/MinSizeRel -- install \
-  && rm -rf build src
+# Install ROCm/HIP.
+ARG ROCM_VERSION=6.1.1
+RUN apt-get update && \
+    apt-get install -y rocm-hip-runtime-dev${ROCM_VERSION} && \
+    apt-get clean -y
+ENV HIP_PLATFORM=amd

--- a/ubuntu2004_rocm/rocm-pin-600
+++ b/ubuntu2004_rocm/rocm-pin-600
@@ -1,0 +1,3 @@
+Package: *
+Pin: release o=repo.radeon.com
+Pin-Priority: 600

--- a/ubuntu2004_rocm/rocm.list
+++ b/ubuntu2004_rocm/rocm.list
@@ -1,0 +1,1 @@
+deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/6.1.1 focal main

--- a/ubuntu2004_rocm_oneapi/Dockerfile
+++ b/ubuntu2004_rocm_oneapi/Dockerfile
@@ -1,49 +1,49 @@
+# Docker machinery, part of the ACTS project
 #
-# Image building the Intel LLVM compiler from scratch, with Intel and AMD
-# backend support.
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
+# Mozilla Public License Version 2.0
 
-# Base the image on the repository's ubuntu2004_rocm configuration.
-FROM ghcr.io/acts-project/ubuntu2004_rocm:v36
+# Start from the (at the time of writing) latest Acts Ubuntu 20.04 image.
+FROM ghcr.io/acts-project/ubuntu2004:v43
 
-# Build the Intel DPC++ compiler from source.
-ARG LLVM_VERSION=2022-12
-ARG LLVM_SOURCE_DIR=/root/llvm
-ARG LLVM_BINARY_DIR=/root/build
-RUN git clone https://github.com/intel/llvm.git ${LLVM_SOURCE_DIR} &&          \
-    cd ${LLVM_SOURCE_DIR}/ && git checkout ${LLVM_VERSION} &&                  \
-    cmake -DCMAKE_BUILD_TYPE=Release                                           \
-       -DCMAKE_INSTALL_PREFIX=${PREFIX}                                        \
-       -DLLVM_ENABLE_ASSERTIONS=ON -DCMAKE_INSTALL_LIBDIR=lib                  \
-       -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU"                                    \
-       -DLLVM_EXTERNAL_PROJECTS="sycl;sycl-fusion;llvm-spirv;opencl;libdevice;xpti;xptifw" \
-       -DLLVM_ENABLE_PROJECTS="clang;compiler-rt;sycl;sycl-fusion;llvm-spirv;opencl;libdevice;xpti;xptifw;libclc;lld;clang-tools-extra;openmp" \
-       -DLLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR=${LLVM_SOURCE_DIR}/llvm-spirv     \
-       -DLLVM_EXTERNAL_SYCL_SOURCE_DIR=${LLVM_SOURCE_DIR}/sycl                 \
-       -DLLVM_EXTERNAL_SYCL_FUSION_SOURCE_DIR=${LLVM_SOURCE_DIR}/sycl-fusion   \
-       -DLLVM_EXTERNAL_LIBDEVICE_SOURCE_DIR=${LLVM_SOURCE_DIR}/libdevice       \
-       -DLLVM_EXTERNAL_XPTI_SOURCE_DIR=${LLVM_SOURCE_DIR}/xpti                 \
-       -DXPTI_SOURCE_DIR=${LLVM_SOURCE_DIR}/xpti                               \
-       -DLLVM_EXTERNAL_XPTIFW_SOURCE_DIR=${LLVM_SOURCE_DIR}/xptifw             \
-       -DLIBCLC_TARGETS_TO_BUILD="amdgcn--;amdgcn--amdhsa"                     \
-       -DLIBCLC_GENERATE_REMANGLED_VARIANTS=ON                                 \
-       -DLLVM_BUILD_TOOLS=ON -DSYCL_ENABLE_WERROR=OFF                          \
-       -DSYCL_INCLUDE_TESTS=OFF -DLLVM_ENABLE_DOXYGEN=OFF                      \
-       -DLLVM_ENABLE_SPHINX=OFF -DBUILD_SHARED_LIBS=OFF                        \
-       -DSYCL_ENABLE_XPTI_TRACING=ON -DLLVM_ENABLE_LLD=OFF                     \
-       -DLLVM_ENABLE_PIC=ON -DLLVM_ENABLE_RTTI=ON -DXPTI_ENABLE_WERROR=OFF     \
-       -DOpenCL_INSTALL_KHRONOS_ICD_LOADER=TRUE                                \
-       -DSYCL_ENABLE_PLUGINS="opencl;level_zero;hip"                           \
-       -DSYCL_ENABLE_KERNEL_FUSION=ON                                          \
-       -S ${LLVM_SOURCE_DIR}/llvm/ -B ${LLVM_BINARY_DIR} &&                    \
-    export MAKEFLAGS=-j`nproc` &&                                              \
-    cmake --build ${LLVM_BINARY_DIR} --target intrinsics_gen &&                \
-    cmake --build ${LLVM_BINARY_DIR} &&                                        \
-    cmake --build ${LLVM_BINARY_DIR} --target sycl-toolchain &&                \
-    cmake --install ${LLVM_BINARY_DIR} &&                                      \
-    rm -rf ${LLVM_SOURCE_DIR} ${LLVM_BINARY_DIR}
+# Some description for the image.
+LABEL description="Ubuntu 20.04 with Acts dependencies and ROCm/HIP + oneAPI"
+LABEL maintainer="Paul Gessinger <paul.gessinger@cern.ch"
 
-# Set up the correct runtime environment for using the compiler(s).
-ENV CC="${PREFIX}/bin/clang"
-ENV CXX="${PREFIX}/bin/clang++"
-ENV SYCLCXX="${CXX} -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx803"
+# Set up the ROCm package signing key.
+RUN mkdir --parents --mode=0755 /etc/apt/keyrings && \
+    curl -SL https://repo.radeon.com/rocm/rocm.gpg.key | \
+    gpg --dearmor > /etc/apt/keyrings/rocm.gpg
+
+# Set up the ROCm repository.
+COPY rocm.list /etc/apt/sources.list.d/
+COPY rocm-pin-600 /etc/apt/preferences.d/
+
+# Install ROCm/HIP.
+ARG ROCM_VERSION=5.4.6
+RUN apt-get update && \
+    apt-get install -y rocm-hip-runtime-dev${ROCM_VERSION} && \
+    apt-get clean -y
+ENV HIP_PLATFORM=amd
+
+# Set up the Intel package signing key.
+RUN curl -SL https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \
+    gpg --dearmor > /usr/share/keyrings/oneapi-archive-keyring.gpg
+
+# Set up the oneAPI repository.
+COPY oneapi.list /etc/apt/sources.list.d/
+
+# Install oneAPI.
+ARG ONEAPI_VERSION=2024.1
+RUN apt-get update && \
+    apt-get install -y intel-oneapi-compiler-dpcpp-cpp-${ONEAPI_VERSION} && \
+    apt-get clean -y
+
+# Set up the oneAPI environment. Note that one *MUST* source the
+# /opt/intel/oneapi/setvars.sh script to make the following work. Which has to
+# be done in the respective CI scripts.
+ENV CC="clang"
+ENV CXX="clang++"
+ENV SYCLCXX="clang++ -fsycl"
+ENV SYCLFLAGS="-fsycl-targets=spir64,spir64_x86_64,amd_gpu_gfx803 -Xclang -opaque-pointers"

--- a/ubuntu2004_rocm_oneapi/oneapi.list
+++ b/ubuntu2004_rocm_oneapi/oneapi.list
@@ -1,0 +1,1 @@
+deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main

--- a/ubuntu2004_rocm_oneapi/rocm-pin-600
+++ b/ubuntu2004_rocm_oneapi/rocm-pin-600
@@ -1,0 +1,3 @@
+Package: *
+Pin: release o=repo.radeon.com
+Pin-Priority: 600

--- a/ubuntu2004_rocm_oneapi/rocm.list
+++ b/ubuntu2004_rocm_oneapi/rocm.list
@@ -1,0 +1,1 @@
+deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/5.4.6 focal main


### PR DESCRIPTION
This is a fairly big design change that I'm proposing here. I'd like to switch to having all of the "GPU images" be based on the "vanilla image", just putting the GPU SDKs on top of that base, vanilla image.

There are a number of reasons behind all of this.
  - I want to start using Intel's "official" oneAPI binaries in our SYCL tests, instead of hand-built versions. This will allow us to side-step https://github.com/oneapi-src/oneDPL/issues/1060 for now, and make it possible to forge ahead with https://github.com/acts-project/traccc/pull/442 finally. (The oneAPI installation comes with an FPGA simulator and a CPU SYCL device out of the box. Which will allow us to link directly against oneDPL in `traccc_sycl`.)
  - The updated ROCm images should also help with the work that @StewMH has been doing recently, to bring ROCm/HIP support into `traccc`.

Note that I only went with a "single layer" of image inheritance in the end. So, the CUDA+oneAPI and ROCm+oneAPI images are built on top of the same "vanilla" Ubuntu 20.04 base image that the "non-hybrid" images are also built on top of. This is for 2 reasons:
  - Whenever adding changes to the Ubuntu 20.04 image, we'll already have to deploy the updated images in 2 steps. (Since we'll need to tag the new base image before we could build and tag the new derived images.) Didn't want to make it into a 3 step process.
  - This allows us to use a newer version of ROCm, CUDA or oneAPI on their own, than in the "combined images". This is absolutely needed, already with the current ROCm+oneAPI image.

Also note that I went with [oneAPI 2024.1](https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-dpc-c-compiler-release-notes.html) as the oneAPI version in all the images. It is not actually functional with the current `traccc` main branch just yet. But with https://github.com/acts-project/traccc/pull/591 and https://github.com/acts-project/detray/pull/734 having gone in already, by the time that we get a new tag of this repository, we'll be able to use these images. :wink:

Finally: Note that I didn't add the [Codeplay plugins](https://codeplay.com/solutions/oneapi/plugins/) to the "combined images". But this doesn't actually prevent us from testing the build of SYCL code with an NVIDIA or AMD backend. It just means that we can't (currently) runtime test the binaries using these images. :frowning: I intend to figure out later on how to install these plugins, but for this first PR it didn't seem absolutely necessary. (Unfortunately the download of the pre-built Codeplay binaries cannot be automated at the moment.)

Also pinging @beomki-yeo and @stephenswat for info.