### PR TITLE
oneAPI / SYCL Image Updates, master branch (2024.05.30.)

### DIFF
--- a/ubuntu2004_cuda_oneapi/Dockerfile
+++ b/ubuntu2004_cuda_oneapi/Dockerfile
@@ -54,4 +54,4 @@ RUN apt-get update && \
 ENV CC="clang"
 ENV CXX="clang++"
 ENV SYCLCXX="clang++ -fsycl"
-ENV SYCLFLAGS="-fsycl-targets=spir64,spir64_x86_64,nvidia_gpu_sm_75 -Wno-unknown-cuda-version -Xclang -opaque-pointers"
+ENV SYCLFLAGS="-fsycl-targets=nvidia_gpu_sm_75 -Wno-unknown-cuda-version"

--- a/ubuntu2004_rocm_oneapi/Dockerfile
+++ b/ubuntu2004_rocm_oneapi/Dockerfile
@@ -46,4 +46,4 @@ RUN apt-get update && \
 ENV CC="clang"
 ENV CXX="clang++"
 ENV SYCLCXX="clang++ -fsycl"
-ENV SYCLFLAGS="-fsycl-targets=spir64,spir64_x86_64,amd_gpu_gfx803 -Xclang -opaque-pointers"
+ENV SYCLFLAGS="-fsycl-targets=amd_gpu_gfx1031"


### PR DESCRIPTION
Simplified the SYCL build flags for AMD and NVIDIA backends.

The main motivation was to change the setup of the AMD backend. Since as it turns out, [traccc](https://github.com/acts-project/traccc) cannot be compiled for the `gfx803` architecture (which is what my personal RX580 card has...) anymore. :thinking: One gets such a scary crash with it during linking:

```
LLVM ERROR: failed to find free scratch register
PLEASE submit a bug report to https://software.intel.com/en-us/support/priority-support and include the crash backtrace.
Stack dump:
0.	Program arguments: /opt/intel/oneapi/compiler/2024.1/bin/compiler/lld -flavor gnu -m elf64_amdgpu --no-undefined -shared -plugin-opt=-amdgpu-internalize-symbols -plugin-opt=mcpu=gfx803 -plugin-opt=O3 --lto-CGO3 --whole-archive -o /tmp/clusterization_algorithm-gfx803-714b28-14499a.out /tmp/clusterization_algorithm-gfx803-52cb02-3bd338.o --no-whole-archive
1.	Running pass 'CallGraph Pass Manager' on module 'ld-temp.o'.
2.	Running pass 'Prologue/Epilogue Insertion & Frame Finalization' on function ''
 #0 0x000055fc78c39f73 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/opt/intel/oneapi/compiler/2024.1/bin/compiler/lld+0x2b98f73)
 #1 0x000055fc78c38260 llvm::sys::RunSignalHandlers() (/opt/intel/oneapi/compiler/2024.1/bin/compiler/lld+0x2b97260)
 #2 0x000055fc78c3a8c4 SignalHandler(int) Signals.cpp:0:0
 #3 0x00007f6a91bf8420 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x14420)
 #4 0x00007f6a91a3500b raise (/lib/x86_64-linux-gnu/libc.so.6+0x4300b)
 #5 0x00007f6a91a14859 abort (/lib/x86_64-linux-gnu/libc.so.6+0x22859)
 #6 0x000055fc78bd442c llvm::report_fatal_error(llvm::Twine const&, bool) (/opt/intel/oneapi/compiler/2024.1/bin/compiler/lld+0x2b3342c)
 #7 0x000055fc78bd4315 (/opt/intel/oneapi/compiler/2024.1/bin/compiler/lld+0x2b33315)
 #8 0x000055fc79420fe6 llvm::PrologEpilogSGPRSpillBuilder::saveToMemory(int) const SIFrameLowering.cpp:0:0
 #9 0x000055fc7941ce92 llvm::SIFrameLowering::emitCSRSpillStores(llvm::MachineFunction&, llvm::MachineBasicBlock&, llvm::MachineInstrBundleIterator<llvm::MachineInstr, false>, llvm::DebugLoc&, llvm::LiveRegUnits&, llvm::Register, llvm::Register) const SIFrameLowering.cpp:0:0
#10 0x000055fc7941e478 llvm::SIFrameLowering::emitPrologue(llvm::MachineFunction&, llvm::MachineBasicBlock&) const SIFrameLowering.cpp:0:0
#11 0x000055fc7a56c797 (anonymous namespace)::PEI::runOnMachineFunction(llvm::MachineFunction&) PrologEpilogInserter.cpp:0:0
#12 0x000055fc7a4b5528 llvm::MachineFunctionPass::runOnFunction(llvm::Function&) (/opt/intel/oneapi/compiler/2024.1/bin/compiler/lld+0x[441](https://github.com/krasznaa/traccc/actions/runs/9303765862/job/25606824343#step:6:442)4528)
#13 0x000055fc7b4ddb26 llvm::FPPassManager::runOnFunction(llvm::Function&) (/opt/intel/oneapi/compiler/2024.1/bin/compiler/lld+0x543cb26)
#14 0x000055fc7ad96317 (anonymous namespace)::CGPassManager::runOnModule(llvm::Module&) CallGraphSCCPass.cpp:0:0
#15 0x000055fc7b4df2ff llvm::legacy::PassManagerImpl::run(llvm::Module&) (/opt/intel/oneapi/compiler/2024.1/bin/compiler/lld+0x543e2ff)
#16 0x000055fc79939eda codegen(llvm::lto::Config const&, llvm::TargetMachine*, std::__1::function<llvm::Expected<std::__1::unique_ptr<llvm::CachedFileStream, std::__1::default_delete<llvm::CachedFileStream>>> (unsigned int, llvm::Twine const&)>, unsigned int, llvm::Module&, llvm::ModuleSummaryIndex const&) LTOBackend.cpp:0:0
#17 0x000055fc79939558 llvm::lto::backend(llvm::lto::Config const&, std::__1::function<llvm::Expected<std::__1::unique_ptr<llvm::CachedFileStream, std::__1::default_delete<llvm::CachedFileStream>>> (unsigned int, llvm::Twine const&)>, unsigned int, llvm::Module&, llvm::ModuleSummaryIndex&) (/opt/intel/oneapi/compiler/2024.1/bin/compiler/lld+0x3898558)
#18 0x000055fc79928b29 llvm::lto::LTO::runRegularLTO(std::__1::function<llvm::Expected<std::__1::unique_ptr<llvm::CachedFileStream, std::__1::default_delete<llvm::CachedFileStream>>> (unsigned int, llvm::Twine const&)>) (/opt/intel/oneapi/compiler/2024.1/bin/compiler/lld+0x3887b29)
#19 0x000055fc7992822a llvm::lto::LTO::run(std::__1::function<llvm::Expected<std::__1::unique_ptr<llvm::CachedFileStream, std::__1::default_delete<llvm::CachedFileStream>>> (unsigned int, llvm::Twine const&)>, std::__1::function<llvm::Expected<std::__1::function<llvm::Expected<std::__1::unique_ptr<llvm::CachedFileStream, std::__1::default_delete<llvm::CachedFileStream>>> (unsigned int, llvm::Twine const&)>> (unsigned int, llvm::StringRef, llvm::Twine const&)>) (/opt/intel/oneapi/compiler/2024.1/bin/compiler/lld+0x388722a)
#20 0x000055fc78dc75c3 lld::elf::BitcodeCompiler::compile() (/opt/intel/oneapi/compiler/2024.1/bin/compiler/lld+0x2d265c3)
#21 0x000055fc78d254a6 lld::elf::LinkerDriver::link(llvm::opt::InputArgList&) (/opt/intel/oneapi/compiler/2024.1/bin/compiler/lld+0x2c844a6)
#22 0x000055fc78d135d1 lld::elf::LinkerDriver::linkerMain(llvm::ArrayRef<char const*>) (/opt/intel/oneapi/compiler/2024.1/bin/compiler/lld+0x2c725d1)
#23 0x000055fc78d11995 lld::elf::link(llvm::ArrayRef<char const*>, llvm::raw_ostream&, llvm::raw_ostream&, bool, bool) (/opt/intel/oneapi/compiler/2024.1/bin/compiler/lld+0x2c70995)
#24 0x000055fc78c3c509 lld::unsafeLldMain(llvm::ArrayRef<char const*>, llvm::raw_ostream&, llvm::raw_ostream&, llvm::ArrayRef<lld::DriverDef>, bool) (/opt/intel/oneapi/compiler/2024.1/bin/compiler/lld+0x2b9b509)
#25 0x000055fc78bc0654 lld_main(int, char**, llvm::ToolContext const&) (/opt/intel/oneapi/compiler/2024.1/bin/compiler/lld+0x2b1f654)
#26 0x000055fc78bc0cde main (/opt/intel/oneapi/compiler/2024.1/bin/compiler/lld+0x2b1fcde)
#27 0x00007f6a91a16083 __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24083)
#28 0x000055fc78bc0329 _start (/opt/intel/oneapi/compiler/2024.1/bin/compiler/lld+0x2b1f329)
llvm-foreach: Aborted (core dumped)
clang++: error: amdgcn-link command failed with exit code 254 (use -v to see invocation)
Intel(R) oneAPI DPC++/C++ Compiler 2024.1.2 (2024.1.2.20240508)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/intel/oneapi/compiler/2024.1/bin/compiler
clang++: note: diagnostic msg: Error generating preprocessed source(s).
make[2]: *** [device/sycl/CMakeFiles/traccc_sycl.dir/build.make:198: lib/libtraccc_sycl.so.0.11.0] Error 1
make[1]: *** [CMakeFiles/Makefile2:3837: device/sycl/CMakeFiles/traccc_sycl.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

After playing around for a bit, I found that the `gfx1031` architecture (used by our developer machine's RX6700XT card...) still works,

But as long as I was already doing this, I also simplified the images to only build SYCL code for AMD / NVIDIA backends respectably. Since building `traccc::sycl` for both Intel + AMD/NVIDIA backends takes a ridiculous amount of time. Not to mention that it's also pretty fragile.

Pinging @andiwand for info. :wink: