### PR TITLE
Add Ubuntu 22.04 image with CUDA

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -34,6 +34,7 @@ jobs:
           - ubuntu2004_oneapi
           - ubuntu2004_exatrkx
           - ubuntu2204
+          - ubuntu2204_cuda
           - ubuntu2204_clang
           - ubuntu2204_cpp20
           - ubuntu2204_rocm_clang

--- a/ubuntu2204_cuda/Dockerfile
+++ b/ubuntu2204_cuda/Dockerfile
@@ -1,0 +1,33 @@
+# Docker machinery, part of the ACTS project
+#
+# (c) 2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Start from the (at the time of writing) latest Acts Ubuntu 22.04 image.
+FROM ghcr.io/acts-project/ubuntu2204:47
+
+# Some description for the image.
+LABEL description="Ubuntu 22.04 with Acts dependencies and CUDA"
+LABEL maintainer="Stephen Nicholas Swatman <stephen.nicholas.swatman@cern.ch"
+
+# Add the Ubuntu 22.04 CUDA repository.
+RUN curl -SL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb \
+       -o cuda-keyring.deb && \
+    dpkg -i cuda-keyring.deb && \
+    rm cuda-keyring.deb
+
+# Install CUDA.
+ARG CUDA_VERSION=12-4
+RUN apt-get update && \
+    apt-get install -y cuda-compat-${CUDA_VERSION} cuda-cudart-${CUDA_VERSION} \
+                       cuda-libraries-dev-${CUDA_VERSION}                      \
+                       cuda-command-line-tools-${CUDA_VERSION}                 \
+                       cuda-minimal-build-${CUDA_VERSION} &&                   \
+    apt-get clean -y
+
+# Set up the CUDA environment.
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+ENV PATH=/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:${LD_LIBRARY_PATH}


### PR DESCRIPTION
This commit adds a new Ubuntu 22.04 image with all the ACTS dependencies, and an installation of CUDA 12.4.