### PR TITLE
Add a formatting image with `clang-format` 18

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -26,6 +26,7 @@ jobs:
           - centos8-lcg101-gcc11
           - format10
           - format14
+          - format18
           - ubuntu2004
           - ubuntu2004_cuda
           - ubuntu2004_cuda_oneapi

--- a/format18/Dockerfile
+++ b/format18/Dockerfile
@@ -1,0 +1,20 @@
+# Docker machinery, part of the ACTS project
+#
+# (c) 2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+FROM ubuntu:24.04
+
+LABEL description="Ubuntu with clang-format v18"
+LABEL maintainer="Stephen Nicholas Swatman <stephen.nicholas.swatman@cern.ch>"
+# increase whenever any of the RUN commands change
+LABEL version="1"
+
+RUN apt-get -y update \
+  && apt-get -y install clang-format-18 git \
+  && apt-get clean all \
+  && update-alternatives \
+    --install /usr/bin/clang-format clang-format /usr/bin/clang-format-18 100 \
+    --slave /usr/bin/clang-format-diff clang-format-diff /usr/bin/clang-format-diff-18 \
+    --slave /usr/bin/git-clang-format git-clang-format /usr/bin/git-clang-format-18


### PR DESCRIPTION
As we move ahead to using newer compiler features in projects like traccc, some features are not properly formatted by the older versions of `clang-format`. This commit adds a new image with version 18 of `clang-format` which should support a broader range of features.