### PR TITLE
CodePlay oneAPI Plugin Install, master branch (2024.06.20.)

### DIFF
--- a/ubuntu2004_cuda_oneapi/Dockerfile
+++ b/ubuntu2004_cuda_oneapi/Dockerfile
@@ -21,7 +21,7 @@ RUN curl -SL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004
 ARG CUDA_VERSION=12-4
 RUN apt-get update && \
     apt-get install -y cuda-compat-${CUDA_VERSION} cuda-cudart-${CUDA_VERSION} \
-                       cuda-libraries-${CUDA_VERSION}                          \
+                       cuda-libraries-dev-${CUDA_VERSION}                      \
                        cuda-command-line-tools-${CUDA_VERSION}                 \
                        cuda-minimal-build-${CUDA_VERSION} &&                   \
     apt-get clean -y
@@ -47,6 +47,14 @@ ARG ONEAPI_VERSION=2024.1
 RUN apt-get update && \
     apt-get install -y intel-oneapi-compiler-dpcpp-cpp-${ONEAPI_VERSION} && \
     apt-get clean -y
+
+# Install the CodePlay NVIDIA plugin on top of oneAPI.
+ARG CODEPLAY_PLUGIN_VERSION=2024.1.2
+RUN curl -SL \
+    "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=${CODEPLAY_PLUGIN_VERSION}" \
+    -o plugin.sh && \
+    sh plugin.sh --install-dir /opt/intel/oneapi --yes && \
+    rm plugin.sh
 
 # Set up the oneAPI environment. Note that one *MUST* source the
 # /opt/intel/oneapi/setvars.sh script to make the following work. Which has to

--- a/ubuntu2004_rocm_oneapi/Dockerfile
+++ b/ubuntu2004_rocm_oneapi/Dockerfile
@@ -40,6 +40,14 @@ RUN apt-get update && \
     apt-get install -y intel-oneapi-compiler-dpcpp-cpp-${ONEAPI_VERSION} && \
     apt-get clean -y
 
+# Install the CodePlay AMD plugin on top of oneAPI.
+ARG CODEPLAY_PLUGIN_VERSION=2024.1.2
+RUN curl -SL \
+    "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=${CODEPLAY_PLUGIN_VERSION}" \
+    -o plugin.sh && \
+    sh plugin.sh --install-dir /opt/intel/oneapi --yes && \
+    rm plugin.sh
+
 # Set up the oneAPI environment. Note that one *MUST* source the
 # /opt/intel/oneapi/setvars.sh script to make the following work. Which has to
 # be done in the respective CI scripts.


### PR DESCRIPTION
Added the CodePlay plugins to the appropriate images, in the same way as I did in https://github.com/acts-project/traccc/pull/616. (Unfortunately the DEB package based installation didn't work out...)

At the same time fixed a mistake in the CUDA image, making sure that the CUDA libraries could actually be used in the builds. It makes the image a little bigger, but without the development packages, there's not much point in installing the libraries either... :thinking:
