### PR TITLE
Bump `ubuntu2204` version flag

### DIFF
--- a/ubuntu2204/Dockerfile
+++ b/ubuntu2204/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 LABEL description="Ubuntu 22.04 with Acts dependencies"
 LABEL maintainer="Paul Gessinger <paul.gessinger@cern.ch>"
 # increase whenever any of the RUN commands change
-LABEL version="1"
+LABEL version="2"
 
 # DEBIAN_FRONTEND ensures non-blocking operation (tzdata is a problem)
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Bumping the version flag to avoid caching the `apt-get upgrade` step.

I am facing a compiler segfault here https://github.com/acts-project/acts/pull/3170 which happens with gcc 11.3.0 but not with 11.4.0 which is installed by the upgrade.