### PR TITLE
Avoid double trigger push and PR and remove cron

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -2,14 +2,9 @@ name: Build images
 
 on:
   pull_request:
-    types: [opened, reopened]
   push:
-    branches:
-      - '**'
     tags:
       - 'v*'
-  schedule:
-    - cron: '0 3 * * 1'
 
 jobs:
   build:


### PR DESCRIPTION
- Avoids building twice for PRs with push trigger.
- Remove cron as it does not benefit us while caching