### PR TITLE
Add new Ubuntu 24.04 CUDA, ROCm, OneAPI machines

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -24,8 +24,12 @@ jobs:
           - ubuntu2204_clang
           - ubuntu2204_cpp17
           - ubuntu2204_rocm_clang
+          - ubuntu2204_rocm_clang_cxx20
           - ubuntu2404
           - ubuntu2404_cuda
+          - ubuntu2404_cuda_oneapi
+          - ubuntu2404_rocm_oneapi
+          - ubuntu2404_oneapi
           - alma9-base
     steps:
       - uses: actions/checkout@v4

--- a/ubuntu2204_rocm_clang_cxx20/0001-CMake-allow-finding-newer-versions-of-podio.patch
+++ b/ubuntu2204_rocm_clang_cxx20/0001-CMake-allow-finding-newer-versions-of-podio.patch
@@ -1,0 +1,31 @@
+From 76bbcc713a5ef93502b23ed59a68f96dd87318b6 Mon Sep 17 00:00:00 2001
+From: Andre Sailer <andre.philippe.sailer@cern.ch>
+Date: Mon, 24 Jun 2024 15:51:35 +0200
+Subject: [PATCH] CMake: allow finding newer versions of podio
+
+---
+ CMakeLists.txt | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e80779bb..50d167c2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -155,7 +155,13 @@ endif()
+ 
+ if(DD4HEP_USE_EDM4HEP)
+   find_package(EDM4HEP REQUIRED)
+-  find_package(podio 0.16.3 REQUIRED)
++  # we need podio with Frame support (>=0.16.3)
++  # podio is "SameMajorVersion" compatible
++  find_package(podio 0.16.3)  # this will not find 1.0 and newer
++  if(NOT podio_FOUND)
++    # we try to find a newer version now
++    find_package(podio 1.0 REQUIRED)
++  endif()
+ #  DD4HEP_SETUP_EDM4HEP_TARGETS()
+ endif()
+ 
+-- 
+2.39.3
+

--- a/ubuntu2204_rocm_clang_cxx20/Dockerfile
+++ b/ubuntu2204_rocm_clang_cxx20/Dockerfile
@@ -1,0 +1,199 @@
+# Docker machinery, part of the ACTS project
+#
+# (c) 2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+FROM rocm/dev-ubuntu-22.04:6.1
+
+LABEL description="Ubuntu 22.04 with Acts dependencies and ROCm using clang, built using C++20"
+LABEL maintainer="Paul Gessinger <paul.gessinger@cern.ch>"
+# increase whenever any of the RUN commands change
+LABEL version="1"
+
+# DEBIAN_FRONTEND ensures non-blocking operation (tzdata is a problem)
+ENV DEBIAN_FRONTEND noninteractive
+
+# install dependencies from the package manager.
+#
+# see also https://root.cern.ch/build-prerequisites
+RUN apt-get update -y \
+  && apt-get install -y \
+    build-essential \
+    clang \
+    curl \
+    git \
+    freeglut3-dev \
+    libboost-dev \
+    libboost-filesystem-dev \
+    libboost-program-options-dev \
+    libboost-test-dev \
+    libeigen3-dev \
+    libexpat-dev \
+    libftgl-dev \
+    libgl2ps-dev \
+    libglew-dev \
+    libgsl-dev \
+    liblz4-dev \
+    liblzma-dev \
+    libpcre3-dev \
+    libssl-dev \
+    libtbb-dev \
+    libx11-dev \
+    libxext-dev \
+    libxft-dev \
+    libxpm-dev \
+    libxerces-c-dev \
+    libxxhash-dev \
+    libzstd-dev \
+    ninja-build \
+    python3 \
+    python3-dev \
+    python3-pip \
+    rsync \
+    zlib1g-dev \
+    ccache \
+  && apt-get remove -y gcc g++ \
+  && apt-get clean -y
+
+# manual builds for hep-specific packages
+ENV GET curl --location --silent --create-dirs
+ENV UNPACK_TO_SRC tar -xz --strip-components=1 --directory src
+ENV PREFIX /usr/local
+
+# use clang by default
+ENV CC clang
+ENV CXX clang++
+
+# manually install CMake
+RUN apt-get purge -y cmake
+RUN mkdir src \
+  && ${GET} https://github.com/Kitware/CMake/releases/download/v3.30.1/cmake-3.30.1.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && ( \
+    cd src \
+    && ./configure \
+    && make -j $(nproc) \
+    && make install \
+  ) \
+  && rm -rf src
+
+# Geant4
+RUN mkdir src \
+  && ${GET} https://gitlab.cern.ch/geant4/geant4/-/archive/v11.1.1/geant4-v11.1.1.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_CXX_STANDARD=20 \
+    -DGEANT4_BUILD_TLS_MODEL=global-dynamic \
+    -DGEANT4_INSTALL_DATA=OFF \
+    -DGEANT4_USE_GDML=ON \
+    -DGEANT4_USE_SYSTEM_EXPAT=ON \
+    -DGEANT4_USE_SYSTEM_ZLIB=ON \
+    -DGEANT4_INSTALL_PACKAGE_CACHE=OFF \
+  && cmake --build build -- -j $(nproc) install \
+  && rm -rf build src
+
+# HepMC3
+RUN mkdir src \
+  && ${GET} https://gitlab.cern.ch/hepmc/HepMC3/-/archive/3.2.5/HepMC3-3.2.5.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DHEPMC3_BUILD_STATIC_LIBS=OFF \
+    -DHEPMC3_ENABLE_PYTHON=OFF \
+    -DHEPMC3_ENABLE_ROOTIO=OFF \
+    -DHEPMC3_ENABLE_SEARCH=OFF \
+  && cmake --build build -- -j $(nproc) install \
+  && rm -rf build src
+
+# Pythia8
+# requires rsync; installation uses `rsync` instead of `install`
+RUN mkdir src \
+  && ${GET} https://pythia.org/download/pythia83/pythia8309.tgz\
+    | ${UNPACK_TO_SRC} \
+  && cd src \
+  && ./configure --enable-shared --prefix=${PREFIX} \
+  && make -j$(nproc) install \
+  && cd .. \
+  && rm -rf src
+
+# nlohmann's JSON
+RUN mkdir src \
+  && ${GET} https://github.com/nlohmann/json/archive/refs/tags/v3.11.2.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DJSON_BuildTests=OFF \
+  && cmake --build build -- -j $(nproc) install \
+  && rm -rf build src
+
+# ROOT
+RUN mkdir src \
+  && ${GET} https://root.cern/download/root_v6.28.06.source.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_CXX_STANDARD=20 \
+    -Dfail-on-missing=ON \
+    -Dgminimal=ON \
+    -Dgdml=ON \
+    -Dopengl=ON \
+    -Dpyroot=ON \
+    -Droot7=ON \
+  && cmake --build build -- -j $(nproc) install \
+  && rm -rf build src
+
+# environment variables needed to find ROOT libraries
+ENV LD_LIBRARY_PATH /usr/local/lib
+ENV PYTHON_PATH /usr/local/lib
+
+# podio
+RUN mkdir src \
+  && ${GET} https://github.com/AIDASoft/podio/archive/refs/tags/v01-00-01.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -USE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- -j $(nproc) install \
+  && rm -rf build src
+
+# EDM4hep
+RUN pip3 install jinja2 pyyaml \
+  && mkdir src \
+  && ${GET} https://github.com/key4hep/EDM4hep/archive/refs/tags/v00-10-05.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -DUSE_EXTERNAL_CATCH2=OFF \
+  && cmake --build build -- -j $(nproc) install \
+  && rm -rf build src
+
+# DD4hep
+# requires Geant4 and ROOT and must come last
+ADD 0001-CMake-allow-finding-newer-versions-of-podio.patch .
+RUN mkdir src \
+  && ${GET} https://github.com/AIDASoft/DD4hep/archive/v01-29.tar.gz \
+    | ${UNPACK_TO_SRC} \
+  && patch -p1 -d src < 0001-CMake-allow-finding-newer-versions-of-podio.patch \
+  && cmake -B build -S src -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_STANDARD=20 \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_PREFIX_PATH=${PREFIX} \
+    -DBUILD_TESTING=OFF \
+    -DDD4HEP_BUILD_PACKAGES="DDG4 DDDetectors DDRec UtilityApps" \
+    -DDD4HEP_IGNORE_GEANT4_TLS=ON \
+    -DDD4HEP_USE_GEANT4=ON \
+    -DDD4HEP_USE_XERCESC=ON \
+    -DDD4HEP_USE_EDM4HEP=ON \
+  && cmake --build build -- -j $(nproc) install \
+  && rm -rf build src
+
+COPY download_geant4_data.sh /usr/local/bin

--- a/ubuntu2204_rocm_clang_cxx20/download_geant4_data.sh
+++ b/ubuntu2204_rocm_clang_cxx20/download_geant4_data.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+data_dir=/usr/local/share/Geant4-10.6.1/data
+
+mkdir $data_dir
+cd $data_dir
+
+
+function dl {
+    url=$1
+    echo "Downloading $url"
+    curl --location $url | tar -xz
+}
+
+dl https://geant4-data.web.cern.ch/datasets/G4NDL.4.6.tar.gz
+dl https://geant4-data.web.cern.ch/datasets/G4EMLOW.7.9.1.tar.gz
+dl https://geant4-data.web.cern.ch/datasets/G4PhotonEvaporation.5.5.tar.gz
+dl https://geant4-data.web.cern.ch/datasets/G4RadioactiveDecay.5.4.tar.gz
+dl https://geant4-data.web.cern.ch/datasets/G4PARTICLEXS.2.1.tar.gz
+dl https://geant4-data.web.cern.ch/datasets/G4PII.1.3.tar.gz
+dl https://geant4-data.web.cern.ch/datasets/G4RealSurface.2.1.1.tar.gz
+dl https://geant4-data.web.cern.ch/datasets/G4SAIDDATA.2.0.tar.gz
+dl https://geant4-data.web.cern.ch/datasets/G4ABLA.3.1.tar.gz
+dl https://geant4-data.web.cern.ch/datasets/G4INCL.1.0.tar.gz
+dl https://geant4-data.web.cern.ch/datasets/G4ENSDFSTATE.2.2.tar.gz

--- a/ubuntu2404_cuda/Dockerfile
+++ b/ubuntu2404_cuda/Dockerfile
@@ -1,9 +1,9 @@
-FROM ghcr.io/acts-project/ubuntu2404:47
+FROM ghcr.io/acts-project/ubuntu2404:53
 
 LABEL description="Ubuntu 24.04 with Acts dependencies and CUDA"
 LABEL maintainer="Stephen Nicholas Swatman <stephen.nicholas.swatman@cern.ch>"
 # increase whenever any of the RUN commands change
-LABEL version="1"
+LABEL version="2"
 
 # DEBIAN_FRONTEND ensures non-blocking operation (tzdata is a problem)
 ENV DEBIAN_FRONTEND noninteractive

--- a/ubuntu2404_cuda_oneapi/Dockerfile
+++ b/ubuntu2404_cuda_oneapi/Dockerfile
@@ -1,0 +1,65 @@
+# Docker machinery, part of the ACTS project
+#
+# (c) 2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Start from the (at the time of writing) latest Acts Ubuntu 24.04 image.
+FROM ghcr.io/acts-project/ubuntu2404:53
+
+# Some description for the image.
+LABEL description="Ubuntu 24.04 with Acts dependencies and CUDA + oneAPI"
+LABEL maintainer="Stephen Nicholas Swatman <stephen.nicholas.swatman@cern.ch>"
+
+# Add the Ubuntu 24.04 CUDA repository.
+RUN curl -SL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb \
+       -o cuda-keyring.deb && \
+    dpkg -i cuda-keyring.deb && \
+    rm cuda-keyring.deb
+
+# Install CUDA.
+ARG CUDA_VERSION=12-5
+RUN apt-get update && \
+    apt-get install -y cuda-compat-${CUDA_VERSION} cuda-cudart-${CUDA_VERSION} \
+                       cuda-libraries-dev-${CUDA_VERSION}                      \
+                       cuda-command-line-tools-${CUDA_VERSION}                 \
+                       cuda-minimal-build-${CUDA_VERSION} &&                   \
+    apt-get clean -y
+
+# Set up the CUDA environment.
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+ENV PATH=/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
+ENV CUDAHOSTCXX="clang++"
+ENV CUDAFLAGS="-allow-unsupported-compiler"
+
+# Set up the Intel package signing key.
+RUN mkdir --parents --mode=0755 /etc/apt/keyrings && \
+    curl -SL https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \
+    gpg --dearmor > /usr/share/keyrings/oneapi-archive-keyring.gpg
+
+# Set up the oneAPI repository.
+COPY oneapi.list /etc/apt/sources.list.d/
+
+# Install oneAPI.
+ARG ONEAPI_VERSION=2024.2
+RUN apt-get update && \
+    apt-get install -y intel-oneapi-compiler-dpcpp-cpp-${ONEAPI_VERSION} && \
+    apt-get clean -y
+
+# Install the CodePlay NVIDIA plugin on top of oneAPI.
+ARG CODEPLAY_PLUGIN_VERSION=2024.2
+RUN curl -SL \
+    "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=${CODEPLAY_PLUGIN_VERSION}" \
+    -o plugin.sh && \
+    sh plugin.sh --install-dir /opt/intel/oneapi --yes && \
+    rm plugin.sh
+
+# Set up the oneAPI environment. Note that one *MUST* source the
+# /opt/intel/oneapi/setvars.sh script to make the following work. Which has to
+# be done in the respective CI scripts.
+ENV CC="clang"
+ENV CXX="clang++"
+ENV SYCLCXX="clang++"
+ENV SYCLFLAGS="-fsycl -fsycl-targets=nvidia_gpu_sm_75 -Wno-unknown-cuda-version"

--- a/ubuntu2404_cuda_oneapi/oneapi.list
+++ b/ubuntu2404_cuda_oneapi/oneapi.list
@@ -1,0 +1,1 @@
+deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main

--- a/ubuntu2404_oneapi/Dockerfile
+++ b/ubuntu2404_oneapi/Dockerfile
@@ -1,0 +1,34 @@
+# Docker machinery, part of the ACTS project
+#
+# (c) 2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Start from the (at the time of writing) latest Acts Ubuntu 24.04 image.
+FROM ghcr.io/acts-project/ubuntu2404:53
+
+# Some description for the image.
+LABEL description="Ubuntu 24.04 with Acts dependencies and oneAPI"
+LABEL maintainer="Stephen Nicholas Swatman <stephen.nicholas.swatman@cern.ch>"
+
+# Set up the Intel package signing key.
+RUN mkdir --parents --mode=0755 /etc/apt/keyrings && \
+    curl -SL https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \
+    gpg --dearmor > /usr/share/keyrings/oneapi-archive-keyring.gpg
+
+# Set up the oneAPI repository.
+COPY oneapi.list /etc/apt/sources.list.d/
+
+# Install oneAPI.
+ARG ONEAPI_VERSION=2024.2
+RUN apt-get update && \
+    apt-get install -y intel-oneapi-compiler-dpcpp-cpp-${ONEAPI_VERSION} && \
+    apt-get clean -y
+
+# Set up the environment. Note that one *MUST* source the
+# /opt/intel/oneapi/setvars.sh script to make the following work. Which has to
+# be done in the respective CI scripts.
+ENV CC="clang"
+ENV CXX="clang++"
+ENV SYCLCXX="clang++"
+ENV SYCLFLAGS="-fsycl -fsycl-targets=spir64,spir64_x86_64"

--- a/ubuntu2404_oneapi/oneapi.list
+++ b/ubuntu2404_oneapi/oneapi.list
@@ -1,0 +1,1 @@
+deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main

--- a/ubuntu2404_rocm_oneapi/Dockerfile
+++ b/ubuntu2404_rocm_oneapi/Dockerfile
@@ -1,0 +1,57 @@
+# Docker machinery, part of the ACTS project
+#
+# (c) 2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Start from the (at the time of writing) latest Acts Ubuntu 24.04 image.
+FROM ghcr.io/acts-project/ubuntu2404:53
+
+# Some description for the image.
+LABEL description="Ubuntu 24.04 with Acts dependencies and ROCm/HIP + oneAPI"
+LABEL maintainer="Stephen Nicholas Swatman <stephen.nicholas.swatman@cern.ch>"
+
+# Set up the ROCm package signing key.
+RUN mkdir --parents --mode=0755 /etc/apt/keyrings && \
+    curl -SL https://repo.radeon.com/rocm/rocm.gpg.key | \
+    gpg --dearmor > /etc/apt/keyrings/rocm.gpg
+
+# Set up the ROCm repository.
+COPY rocm.list /etc/apt/sources.list.d/
+COPY rocm-pin-600 /etc/apt/preferences.d/
+
+# Install ROCm/HIP.
+ARG ROCM_VERSION=6.1.0
+RUN apt-get update && \
+    apt-get install -y rocm-hip-runtime-dev${ROCM_VERSION} && \
+    apt-get clean -y
+ENV HIP_PLATFORM=amd
+
+# Set up the Intel package signing key.
+RUN curl -SL https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \
+    gpg --dearmor > /usr/share/keyrings/oneapi-archive-keyring.gpg
+
+# Set up the oneAPI repository.
+COPY oneapi.list /etc/apt/sources.list.d/
+
+# Install oneAPI.
+ARG ONEAPI_VERSION=2024.2
+RUN apt-get update && \
+    apt-get install -y intel-oneapi-compiler-dpcpp-cpp-${ONEAPI_VERSION} && \
+    apt-get clean -y
+
+# Install the CodePlay AMD plugin on top of oneAPI.
+ARG CODEPLAY_PLUGIN_VERSION=2024.2.0
+RUN curl -SL \
+    "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=${CODEPLAY_PLUGIN_VERSION}" \
+    -o plugin.sh && \
+    sh plugin.sh --install-dir /opt/intel/oneapi --yes && \
+    rm plugin.sh
+
+# Set up the oneAPI environment. Note that one *MUST* source the
+# /opt/intel/oneapi/setvars.sh script to make the following work. Which has to
+# be done in the respective CI scripts.
+ENV CC="icx"
+ENV CXX="icpx"
+ENV SYCLCXX="icpx"
+ENV SYCLFLAGS="-fsycl -fsycl-targets=amd_gpu_gfx1031"

--- a/ubuntu2404_rocm_oneapi/oneapi.list
+++ b/ubuntu2404_rocm_oneapi/oneapi.list
@@ -1,0 +1,1 @@
+deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main

--- a/ubuntu2404_rocm_oneapi/rocm-pin-600
+++ b/ubuntu2404_rocm_oneapi/rocm-pin-600
@@ -1,0 +1,3 @@
+Package: *
+Pin: release o=repo.radeon.com
+Pin-Priority: 600

--- a/ubuntu2404_rocm_oneapi/rocm.list
+++ b/ubuntu2404_rocm_oneapi/rocm.list
@@ -1,0 +1,1 @@
+deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/6.1 focal main


### PR DESCRIPTION
This commit adds three new images based on Ubuntu 24.04, with OneAPI and, optionally, the AMD ROCm and NVIDIA CUDA plugins. Also adds a new Ubuntu 22.04 image with the dependencies built using C++20.