### PR TITLE
Update Ubuntu 24.04 ROCm+OneAPI image

### DIFF
--- a/ubuntu2404_rocm_oneapi/Dockerfile
+++ b/ubuntu2404_rocm_oneapi/Dockerfile
@@ -42,9 +42,9 @@ RUN apt-get update && \
     apt-get clean -y
 
 # Install the CodePlay AMD plugin on top of oneAPI.
-ARG CODEPLAY_PLUGIN_VERSION=2024.2.0
-RUN curl -SL \
-    "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=${CODEPLAY_PLUGIN_VERSION}" \
+RUN ONEAPI_INSTALLED_VERSION=$(/opt/intel/oneapi/compiler/latest/bin/icpx --version | grep -oP '(?<=Intel\(R\) oneAPI DPC\+\+\/C\+\+ Compiler )[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+') && \
+    echo "Installing CodePlay for OneAPI ${ONEAPI_INSTALLED_VERSION}" && \
+    curl -SL "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=${ONEAPI_INSTALLED_VERSION}&filters[]=${ROCM_VERSION}&filters[]=linux" \
     -o plugin.sh && \
     sh plugin.sh --install-dir /opt/intel/oneapi --yes && \
     rm plugin.sh

--- a/ubuntu2404_rocm_oneapi/rocm.list
+++ b/ubuntu2404_rocm_oneapi/rocm.list
@@ -1,1 +1,1 @@
-deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/6.1 focal main
+deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/6.1 jammy main


### PR DESCRIPTION
This updates updates the version of OneAPI used to 2024.2.1, updates the ROCm repository, and also makes the call to the CodePlay download API more precisely defined.