### PR TITLE
CUDA 12.6 + oneAPI 2025.0 Update, main branch (2024.11.28.)

### DIFF
--- a/alma9_cuda_oneapi/Dockerfile
+++ b/alma9_cuda_oneapi/Dockerfile
@@ -20,7 +20,7 @@ RUN dnf install -y boost boost-devel
 
 # Set up the CUDA repository.
 COPY cuda.repo /etc/yum.repos.d/cuda.repo
-ARG CUDA_VERSION=12-5
+ARG CUDA_VERSION=12-6
 
 # Install CUDA
 RUN dnf install -y cuda-${CUDA_VERSION}.x86_64
@@ -29,13 +29,13 @@ RUN dnf install -y cuda-${CUDA_VERSION}.x86_64
 COPY oneapi.repo /etc/yum.repos.d/oneapi.repo
 
 # Install oneAPI.
-ARG ONEAPI_VERSION=2024.2
+ARG ONEAPI_VERSION=2025.0
 RUN dnf install -y intel-oneapi-compiler-dpcpp-cpp-${ONEAPI_VERSION}
 
 # Install the CodePlay AMD plugin on top of oneAPI.
-ARG CODEPLAY_PLUGIN_VERSION=2024.2
+ARG CODEPLAY_PLUGIN_VERSION=2025.0
 RUN curl -SL \
-    "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=${CODEPLAY_PLUGIN_VERSION}" \
+    "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&filters[]=linux&version=${CODEPLAY_PLUGIN_VERSION}" \
     -o plugin.sh && \
     sh plugin.sh --install-dir /opt/intel/oneapi --yes && \
     rm plugin.sh

--- a/alma9_rocm_oneapi/Dockerfile
+++ b/alma9_rocm_oneapi/Dockerfile
@@ -30,13 +30,12 @@ ENV HIP_PLATFORM=amd
 COPY oneapi.repo /etc/yum.repos.d/oneapi.repo
 
 # Install oneAPI.
-ARG ONEAPI_VERSION=2024.2
+ARG ONEAPI_VERSION=2025.0
 RUN dnf install -y intel-oneapi-compiler-dpcpp-cpp-${ONEAPI_VERSION}
 
 # Install the CodePlay AMD plugin on top of oneAPI.
-RUN ONEAPI_INSTALLED_VERSION=$(/opt/intel/oneapi/compiler/latest/bin/icpx --version | grep -oP '(?<=Intel\(R\) oneAPI DPC\+\+\/C\+\+ Compiler )[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+') && \
-    echo "Installing CodePlay for OneAPI ${ONEAPI_INSTALLED_VERSION}" && \
-    curl -SL "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=${ONEAPI_INSTALLED_VERSION}&filters[]=${ROCM_VERSION}&filters[]=linux" \
+ARG CODEPLAY_PLUGIN_VERSION=2025.0
+RUN curl -SL "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=${CODEPLAY_PLUGIN_VERSION}&filters[]=${ROCM_VERSION}&filters[]=linux" \
     -o plugin.sh && \
     sh plugin.sh --install-dir /opt/intel/oneapi --yes && \
     rm plugin.sh

--- a/ubuntu2204_cuda/Dockerfile
+++ b/ubuntu2204_cuda/Dockerfile
@@ -5,7 +5,7 @@
 # Mozilla Public License Version 2.0
 
 # Start from the (at the time of writing) latest Acts Ubuntu 22.04 image.
-FROM ghcr.io/acts-project/ubuntu2204:55
+FROM ghcr.io/acts-project/ubuntu2204:68
 
 # Some description for the image.
 LABEL description="Ubuntu 22.04 with Acts dependencies and CUDA"
@@ -18,7 +18,7 @@ RUN curl -SL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204
     rm cuda-keyring.deb
 
 # Install CUDA.
-ARG CUDA_VERSION=12-4
+ARG CUDA_VERSION=12-6
 RUN apt-get update && \
     apt-get install -y cuda-compat-${CUDA_VERSION} cuda-cudart-${CUDA_VERSION} \
                        cuda-libraries-dev-${CUDA_VERSION}                      \

--- a/ubuntu2204_cuda_oneapi/Dockerfile
+++ b/ubuntu2204_cuda_oneapi/Dockerfile
@@ -6,7 +6,7 @@
 
 # Start from the (at the time of writing) latest Acts Ubuntu 24.04 image.
 # @TODO: Change this
-FROM ghcr.io/acts-project/ubuntu2204:55
+FROM ghcr.io/acts-project/ubuntu2204:68
 
 # Some description for the image.
 LABEL description="Ubuntu 22.04 with Acts dependencies and CUDA + oneAPI"
@@ -19,7 +19,7 @@ RUN curl -SL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204
     rm cuda-keyring.deb
 
 # Install CUDA.
-ARG CUDA_VERSION=12-4
+ARG CUDA_VERSION=12-6
 RUN apt-get update && \
     apt-get install -y cuda-compat-${CUDA_VERSION} cuda-cudart-${CUDA_VERSION} \
                        cuda-libraries-dev-${CUDA_VERSION}                      \
@@ -44,15 +44,15 @@ RUN mkdir --parents --mode=0755 /etc/apt/keyrings && \
 COPY oneapi.list /etc/apt/sources.list.d/
 
 # Install oneAPI.
-ARG ONEAPI_VERSION=2024.2
+ARG ONEAPI_VERSION=2025.0
 RUN apt-get update && \
     apt-get install -y intel-oneapi-compiler-dpcpp-cpp-${ONEAPI_VERSION} && \
     apt-get clean -y
 
 # Install the CodePlay NVIDIA plugin on top of oneAPI.
-ARG CODEPLAY_PLUGIN_VERSION=2024.2
+ARG CODEPLAY_PLUGIN_VERSION=2025.0
 RUN curl -SL \
-    "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=${CODEPLAY_PLUGIN_VERSION}" \
+    "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&filters[]=linux&version=${CODEPLAY_PLUGIN_VERSION}" \
     -o plugin.sh && \
     sh plugin.sh --install-dir /opt/intel/oneapi --yes && \
     rm plugin.sh

--- a/ubuntu2404_cuda_oneapi/Dockerfile
+++ b/ubuntu2404_cuda_oneapi/Dockerfile
@@ -6,7 +6,7 @@
 
 # Start from the (at the time of writing) latest Acts Ubuntu 24.04 image.
 # @TODO: Update this
-FROM ghcr.io/acts-project/ubuntu2404:53
+FROM ghcr.io/acts-project/ubuntu2404:68
 
 # Some description for the image.
 LABEL description="Ubuntu 24.04 with Acts dependencies and CUDA + oneAPI"
@@ -19,7 +19,7 @@ RUN curl -SL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404
     rm cuda-keyring.deb
 
 # Install CUDA.
-ARG CUDA_VERSION=12-5
+ARG CUDA_VERSION=12-6
 RUN apt-get update && \
     apt-get install -y cuda-compat-${CUDA_VERSION} cuda-cudart-${CUDA_VERSION} \
                        cuda-libraries-dev-${CUDA_VERSION}                      \
@@ -44,15 +44,15 @@ RUN mkdir --parents --mode=0755 /etc/apt/keyrings && \
 COPY oneapi.list /etc/apt/sources.list.d/
 
 # Install oneAPI.
-ARG ONEAPI_VERSION=2024.2
+ARG ONEAPI_VERSION=2025.0
 RUN apt-get update && \
     apt-get install -y intel-oneapi-compiler-dpcpp-cpp-${ONEAPI_VERSION} && \
     apt-get clean -y
 
 # Install the CodePlay NVIDIA plugin on top of oneAPI.
-ARG CODEPLAY_PLUGIN_VERSION=2024.2
+ARG CODEPLAY_PLUGIN_VERSION=2025.0
 RUN curl -SL \
-    "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=${CODEPLAY_PLUGIN_VERSION}" \
+    "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&filters[]=linux&version=${CODEPLAY_PLUGIN_VERSION}" \
     -o plugin.sh && \
     sh plugin.sh --install-dir /opt/intel/oneapi --yes && \
     rm plugin.sh

--- a/ubuntu2404_oneapi/Dockerfile
+++ b/ubuntu2404_oneapi/Dockerfile
@@ -6,7 +6,7 @@
 
 # Start from the (at the time of writing) latest Acts Ubuntu 24.04 image.
 # @TODO: Update this
-FROM ghcr.io/acts-project/ubuntu2404:53
+FROM ghcr.io/acts-project/ubuntu2404:68
 
 # Some description for the image.
 LABEL description="Ubuntu 24.04 with Acts dependencies and oneAPI"
@@ -21,7 +21,7 @@ RUN mkdir --parents --mode=0755 /etc/apt/keyrings && \
 COPY oneapi.list /etc/apt/sources.list.d/
 
 # Install oneAPI.
-ARG ONEAPI_VERSION=2024.2
+ARG ONEAPI_VERSION=2025.0
 RUN apt-get update && \
     apt-get install -y intel-oneapi-compiler-dpcpp-cpp-${ONEAPI_VERSION} && \
     apt-get clean -y
@@ -32,4 +32,4 @@ RUN apt-get update && \
 ENV CC="clang"
 ENV CXX="clang++"
 ENV SYCLCXX="clang++"
-ENV SYCLFLAGS="-fsycl -fsycl-targets=spir64,spir64_x86_64"
+ENV SYCLFLAGS="-fsycl"

--- a/ubuntu2404_rocm_oneapi/Dockerfile
+++ b/ubuntu2404_rocm_oneapi/Dockerfile
@@ -6,7 +6,7 @@
 
 # Start from the (at the time of writing) latest Acts Ubuntu 24.04 image.
 # @TODO: Update this
-FROM ghcr.io/acts-project/ubuntu2404:53
+FROM ghcr.io/acts-project/ubuntu2404:68
 
 # Some description for the image.
 LABEL description="Ubuntu 24.04 with Acts dependencies and ROCm/HIP + oneAPI"
@@ -36,15 +36,14 @@ RUN curl -SL https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRO
 COPY oneapi.list /etc/apt/sources.list.d/
 
 # Install oneAPI.
-ARG ONEAPI_VERSION=2024.2
+ARG ONEAPI_VERSION=2025.0
 RUN apt-get update && \
     apt-get install -y intel-oneapi-compiler-dpcpp-cpp-${ONEAPI_VERSION} && \
     apt-get clean -y
 
 # Install the CodePlay AMD plugin on top of oneAPI.
-RUN ONEAPI_INSTALLED_VERSION=$(/opt/intel/oneapi/compiler/latest/bin/icpx --version | grep -oP '(?<=Intel\(R\) oneAPI DPC\+\+\/C\+\+ Compiler )[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+') && \
-    echo "Installing CodePlay for OneAPI ${ONEAPI_INSTALLED_VERSION}" && \
-    curl -SL "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=${ONEAPI_INSTALLED_VERSION}&filters[]=${ROCM_VERSION}&filters[]=linux" \
+ARG CODEPLAY_PLUGIN_VERSION=2025.0
+RUN curl -SL "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=amd&version=${CODEPLAY_PLUGIN_VERSION}&filters[]=${ROCM_VERSION}&filters[]=linux" \
     -o plugin.sh && \
     sh plugin.sh --install-dir /opt/intel/oneapi --yes && \
     rm plugin.sh


### PR DESCRIPTION
Updated everything to [CUDA 12.6](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html) and [oneAPI 2025.0](https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-toolkit-release-notes.html). Since in my experience that's the combination working best with our latest GPU R&D code. :thinking:

I have to admit, I didn't make a test build of every modified image locally. :thinking: So let's see how the CI does...