### PR TITLE
Add Ubuntu 24.04 machine with LLVM 19

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -25,6 +25,7 @@ jobs:
           - ubuntu2204_rocm_clang
           - ubuntu2204_rocm_clang_cxx20
           - ubuntu2404
+          - ubuntu2404_clang19
           - ubuntu2404_cuda
           - ubuntu2404_cuda_oneapi
           - ubuntu2404_rocm_oneapi

--- a/ubuntu2404_clang19/Dockerfile
+++ b/ubuntu2404_clang19/Dockerfile
@@ -1,0 +1,81 @@
+FROM ubuntu:24.04
+
+LABEL description="Ubuntu 24.04 with Acts dependencies"
+LABEL maintainer="Stephen Nicholas Swatman <stephen.nicholas.swatman@cern.ch>"
+# increase whenever any of the RUN commands change
+LABEL version="1"
+
+# DEBIAN_FRONTEND ensures non-blocking operation (tzdata is a problem)
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update -y \
+  && apt-get upgrade -y \
+  && apt-get install -y wget
+
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+RUN echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" >> /etc/apt/sources.list
+
+# install dependencies from the package manager.
+#
+# see also https://root.cern.ch/build-prerequisites
+RUN apt-get update -y \
+  && apt-get upgrade -y \
+  && apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    git-lfs \
+    cmake \
+    freeglut3-dev \
+    libexpat-dev \
+    libftgl-dev \
+    libgl2ps-dev \
+    libglew-dev \
+    libgsl-dev \
+    liblz4-dev \
+    liblzma-dev \
+    libpcre3-dev \
+    libx11-dev \
+    libxext-dev \
+    libxft-dev \
+    libxpm-dev \
+    libxerces-c-dev \
+    libxxhash-dev \
+    libzstd-dev \
+    zstd \
+    ninja-build \
+    python3 \
+    python3-dev \
+    python3-pip \
+    rsync \
+    zlib1g-dev \
+    ccache \
+    python3-venv \
+    libsqlite3-dev \
+    time \
+    clang-19 \
+  && apt-get clean -y
+
+ENV CXX clang++-19
+ENV CC clang-19
+
+# manual builds for hep-specific packages
+ENV GET curl --location --silent --create-dirs
+ENV UNPACK_TO_SRC tar -xz --strip-components=1 --directory src
+ENV PREFIX /usr/local
+
+ENV ONNXRUNTIME_VERSION=1.18.1
+
+# Onnx (download of tar.gz does not work out of the box, since the build.sh script requires a git repository)
+RUN git clone https://github.com/microsoft/onnxruntime src \
+  && (cd src && git checkout v${ONNXRUNTIME_VERSION}) \
+  &&  ./src/build.sh \
+    --config MinSizeRel \
+    --build_shared_lib \
+    --build_dir build \
+    --skip_tests \
+    --allow_running_as_root \
+    --parallel 0 \
+  && cmake --build build/MinSizeRel -- install \
+  && rm -rf build src
+


### PR DESCRIPTION
LLVM 19 adds the new (and very conveniently named) `-Wmissing-template-arg-list-after-template-kw` warning flag which fires a lot on the existing ACTS code. The new version of OneAPI is based on this version of LLVM, which is causing us a bit of grief in e.g. https://github.com/acts-project/traccc/pull/793. In order to resolve this issue I want to add an LLVM 19 build to ACTS.