### PR TITLE
Add clang tools to clang19 image

### DIFF
--- a/ubuntu2404_clang19/Dockerfile
+++ b/ubuntu2404_clang19/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update -y \
     libsqlite3-dev \
     time \
     clang-19 \
+    clang-tools-19 \
     unzip \
     file \
   && apt-get clean -y


### PR DESCRIPTION
CMake seems to require the `clang-scan-deps` executable these days, which the clang19 image does not have. This PR adds that.